### PR TITLE
feat: add game setup editor

### DIFF
--- a/Assets/Editor/GameSetupEditor.cs
+++ b/Assets/Editor/GameSetupEditor.cs
@@ -1,0 +1,159 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+
+/// <summary>
+/// Automates initial game setup by creating required prefabs and
+/// populating all scenes with core objects.
+/// </summary>
+public static class GameSetupEditor
+{
+    private const string CanvasPrefabPath = "Assets/Prefabs/UICanvas.prefab";
+
+    [MenuItem("Tools/Setup Game")]
+    public static void SetupGame()
+    {
+        EnsureSortingLayers();
+        CreateCanvasPrefab();
+
+        var sceneGuids = AssetDatabase.FindAssets("t:scene", new[] { "Assets/Scenes" });
+        foreach (var guid in sceneGuids)
+        {
+            var path = AssetDatabase.GUIDToAssetPath(guid);
+            var scene = EditorSceneManager.OpenScene(path);
+            EnsureSpriteLayers();
+            EnsureGameplayObjects();
+            EditorSceneManager.SaveScene(scene);
+        }
+
+        Debug.Log("Game setup complete.");
+    }
+
+    private static void EnsureSpriteLayers()
+    {
+        EnsureRootObject("Background");
+        EnsureRootObject("Middleground");
+        EnsureRootObject("Foreground");
+    }
+
+    private static void EnsureRootObject(string name)
+    {
+        if (GameObject.Find(name) == null)
+        {
+            new GameObject(name);
+        }
+    }
+
+    private static void EnsureGameplayObjects()
+    {
+        var inventory = Object.FindObjectOfType<InventorySystem>();
+        if (inventory == null)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>("Assets/Prefabs/InventorySystem.prefab");
+            var inst = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+            inventory = inst.GetComponent<InventorySystem>();
+        }
+
+        var ui = Object.FindObjectOfType<UIManager>();
+        if (ui == null)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(CanvasPrefabPath);
+            var inst = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+            ui = inst.GetComponent<UIManager>();
+        }
+
+        var player = Object.FindObjectOfType<PlayerController>();
+        if (player == null)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>("Assets/Prefabs/Player.prefab");
+            var inst = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+            player = inst.GetComponent<PlayerController>();
+        }
+
+        var playerSO = new SerializedObject(player);
+        playerSO.FindProperty("inventory").objectReferenceValue = inventory;
+        playerSO.FindProperty("ui").objectReferenceValue = ui;
+        playerSO.ApplyModifiedProperties();
+    }
+
+    private static void CreateCanvasPrefab()
+    {
+        if (AssetDatabase.LoadAssetAtPath<GameObject>(CanvasPrefabPath) != null)
+            return;
+
+        var canvasGO = new GameObject("Canvas");
+        var canvas = canvasGO.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvasGO.AddComponent<CanvasScaler>();
+        canvasGO.AddComponent<GraphicRaycaster>();
+        var uiManager = canvasGO.AddComponent<UIManager>();
+        var inventoryUI = canvasGO.AddComponent<InventoryUI>();
+
+        var inventoryPanel = new GameObject("InventoryPanel");
+        inventoryPanel.transform.SetParent(canvasGO.transform, false);
+        var panelImage = inventoryPanel.AddComponent<Image>();
+        panelImage.color = new Color(0f, 0f, 0f, 0.5f);
+        inventoryPanel.SetActive(false);
+
+        var inventoryTextGO = new GameObject("InventoryText");
+        inventoryTextGO.transform.SetParent(inventoryPanel.transform, false);
+        var inventoryText = inventoryTextGO.AddComponent<Text>();
+        inventoryText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+
+        var flavourTextGO = new GameObject("FlavourText");
+        flavourTextGO.transform.SetParent(canvasGO.transform, false);
+        var flavourText = flavourTextGO.AddComponent<Text>();
+        flavourText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+
+        var promptGO = new GameObject("Prompt");
+        promptGO.transform.SetParent(canvasGO.transform, false);
+        var promptText = promptGO.AddComponent<Text>();
+        promptText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        promptGO.SetActive(false);
+
+        var uiSO = new SerializedObject(uiManager);
+        uiSO.FindProperty("inventoryText").objectReferenceValue = inventoryText;
+        uiSO.FindProperty("flavourText").objectReferenceValue = flavourText;
+        uiSO.FindProperty("prompt").objectReferenceValue = promptGO;
+        uiSO.ApplyModifiedProperties();
+
+        var invSO = new SerializedObject(inventoryUI);
+        invSO.FindProperty("inventoryPanel").objectReferenceValue = inventoryPanel;
+        invSO.ApplyModifiedProperties();
+
+        var eventSystemGO = new GameObject("EventSystem");
+        eventSystemGO.AddComponent<EventSystem>();
+        eventSystemGO.AddComponent<StandaloneInputModule>();
+
+        PrefabUtility.SaveAsPrefabAsset(canvasGO, CanvasPrefabPath);
+        Object.DestroyImmediate(canvasGO);
+        Object.DestroyImmediate(eventSystemGO);
+    }
+
+    private static void EnsureSortingLayers()
+    {
+        var tagManager = new SerializedObject(AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset")[0]);
+        var layersProp = tagManager.FindProperty("m_SortingLayers");
+        AddSortingLayer(layersProp, "Background");
+        AddSortingLayer(layersProp, "Middleground");
+        AddSortingLayer(layersProp, "Foreground");
+        tagManager.ApplyModifiedProperties();
+    }
+
+    private static void AddSortingLayer(SerializedProperty layersProp, string name)
+    {
+        for (int i = 0; i < layersProp.arraySize; i++)
+        {
+            var entry = layersProp.GetArrayElementAtIndex(i);
+            if (entry.FindPropertyRelative("name").stringValue == name)
+                return;
+        }
+        layersProp.InsertArrayElementAtIndex(layersProp.arraySize);
+        var newEntry = layersProp.GetArrayElementAtIndex(layersProp.arraySize - 1);
+        newEntry.FindPropertyRelative("name").stringValue = name;
+    }
+}
+#endif

--- a/Assets/Editor/GameSetupEditor.cs.meta
+++ b/Assets/Editor/GameSetupEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e14500e25b0b4d9699b942004446b88e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/InventoryUI.cs
+++ b/Assets/Scripts/InventoryUI.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+/// <summary>
+/// Toggles the inventory panel when the player presses a key.
+/// </summary>
+public class InventoryUI : MonoBehaviour
+{
+    [SerializeField] private GameObject inventoryPanel;
+    [SerializeField] private KeyCode toggleKey = KeyCode.I;
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(toggleKey) && inventoryPanel != null)
+        {
+            inventoryPanel.SetActive(!inventoryPanel.activeSelf);
+        }
+    }
+}

--- a/Assets/Scripts/InventoryUI.cs.meta
+++ b/Assets/Scripts/InventoryUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e56b59de3c24a23a488f438c83cf3ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add InventoryUI component for toggling inventory panels
- add editor utility to create canvas prefab, sorting layers, and populate scenes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f28ae7b8832f98bf7aa35be699bf