### PR TITLE
Use outline shader for interactable highlight

### DIFF
--- a/Assets/Materials/OutlineHighlight.mat
+++ b/Assets/Materials/OutlineHighlight.mat
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: OutlineHighlight
+  m_Shader: {fileID: 4800000, guid: 8ec2a7b136b448a1b9bdf4b8a5d6b0e7, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _OutlineSize: 1
+    m_Colors:
+    - _OutlineColor: {r: 1, g: 1, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/OutlineHighlight.mat.meta
+++ b/Assets/Materials/OutlineHighlight.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 95e3c369fa12481998c0428a63a808bf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Highlightable.cs
+++ b/Assets/Scripts/Highlightable.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+/// <summary>
+/// Swaps the sprite's material to an outline version when highlighted.
+/// </summary>
+[RequireComponent(typeof(SpriteRenderer))]
+public class Highlightable : MonoBehaviour
+{
+    [SerializeField] private Material outlineMaterial;
+    private Material originalMaterial;
+    private SpriteRenderer sr;
+
+    private void Awake()
+    {
+        sr = GetComponent<SpriteRenderer>();
+        originalMaterial = sr.material;
+    }
+
+    /// <summary>
+    /// Enable or disable outline highlight.
+    /// </summary>
+    public void SetHighlighted(bool highlighted)
+    {
+        if (sr == null) return;
+        sr.material = highlighted ? outlineMaterial : originalMaterial;
+    }
+}

--- a/Assets/Scripts/Highlightable.cs.meta
+++ b/Assets/Scripts/Highlightable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d781ed1b07534a168e7ec4d1716c10d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -70,6 +70,7 @@ public class PlayerController : MonoBehaviour
         if (nearbyPickups.Count > 0)
         {
             var pickup = nearbyPickups[0];
+            pickup.GetComponent<Highlightable>()?.SetHighlighted(false);
             inventory.AddItem(pickup.Item);
             ui?.RefreshInventory(inventory);
             ui?.ShowFlavourText($"Picked up {pickup.Item.DisplayName}");
@@ -106,6 +107,8 @@ public class PlayerController : MonoBehaviour
         {
             nearbyGhosts.Add(ghost);
         }
+
+        collision.GetComponent<Highlightable>()?.SetHighlighted(true);
     }
 
     private void OnTriggerExit2D(Collider2D collision)
@@ -121,5 +124,7 @@ public class PlayerController : MonoBehaviour
         {
             nearbyGhosts.Remove(ghost);
         }
+
+        collision.GetComponent<Highlightable>()?.SetHighlighted(false);
     }
 }

--- a/Assets/Shaders/OutlineHighlight.shader
+++ b/Assets/Shaders/OutlineHighlight.shader
@@ -1,0 +1,106 @@
+Shader "Custom/SpriteOutline" {
+    Properties {
+        _MainTex ("Sprite Texture", 2D) = "white" {}
+        _OutlineColor ("Outline Color", Color) = (1,1,0,1)
+        _OutlineSize ("Outline Size", Float) = 1
+    }
+    SubShader {
+        Tags {"RenderType"="Transparent" "Queue"="Transparent"}
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend One OneMinusSrcAlpha
+
+        // First pass: draw outline
+        Pass {
+            Name "OUTLINE"
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+            float4 _OutlineColor;
+            float _OutlineSize;
+
+            v2f vert (appdata v) {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target {
+                fixed4 c = tex2D(_MainTex, i.uv);
+                if (c.a == 0) {
+                    float2 offsets[8] = {
+                        float2(_OutlineSize * _MainTex_TexelSize.x, 0),
+                        float2(-_OutlineSize * _MainTex_TexelSize.x, 0),
+                        float2(0, _OutlineSize * _MainTex_TexelSize.y),
+                        float2(0, -_OutlineSize * _MainTex_TexelSize.y),
+                        float2(_OutlineSize * _MainTex_TexelSize.x, _OutlineSize * _MainTex_TexelSize.y),
+                        float2(-_OutlineSize * _MainTex_TexelSize.x, _OutlineSize * _MainTex_TexelSize.y),
+                        float2(_OutlineSize * _MainTex_TexelSize.x, -_OutlineSize * _MainTex_TexelSize.y),
+                        float2(-_OutlineSize * _MainTex_TexelSize.x, -_OutlineSize * _MainTex_TexelSize.y)
+                    };
+                    for (int j = 0; j < 8; j++) {
+                        if (tex2D(_MainTex, i.uv + offsets[j]).a > 0) {
+                            return _OutlineColor;
+                        }
+                    }
+                    return 0;
+                }
+                return 0;
+            }
+            ENDCG
+        }
+
+        // Second pass: draw sprite normally
+        Pass {
+            Name "SPRITE"
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
+            };
+
+            struct v2f {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+                fixed4 color : COLOR;
+            };
+
+            sampler2D _MainTex;
+
+            v2f vert (appdata v) {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                o.color = v.color;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target {
+                fixed4 c = tex2D(_MainTex, i.uv) * i.color;
+                return c;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/OutlineHighlight.shader.meta
+++ b/Assets/Shaders/OutlineHighlight.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8ec2a7b136b448a1b9bdf4b8a5d6b0e7
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add customizable outline shader and material for highlights
- Introduce `Highlightable` component to swap outline material
- Trigger highlight via `PlayerController` on proximity

## Testing
- `echo "Skipping dotnet tests; Unity project" && echo done`


------
https://chatgpt.com/codex/tasks/task_e_68aa1172c47c832f908297f6de98233c