### PR TITLE
Use outline shader for highlighting with verbose debug logs

### DIFF
--- a/Assets/Editor/GameSetupEditor.cs
+++ b/Assets/Editor/GameSetupEditor.cs
@@ -12,6 +12,7 @@ using UnityEngine.EventSystems;
 public static class GameSetupEditor
 {
     private const string CanvasPrefabPath = "Assets/Prefabs/UICanvas.prefab";
+    private const string InventoryButtonPrefabPath = "Assets/Prefabs/InventoryButton.prefab";
 
     [MenuItem("Tools/Setup Game")]
     public static void SetupGame()
@@ -98,10 +99,8 @@ public static class GameSetupEditor
         panelImage.color = new Color(0f, 0f, 0f, 0.5f);
         inventoryPanel.SetActive(false);
 
-        var inventoryTextGO = new GameObject("InventoryText");
-        inventoryTextGO.transform.SetParent(inventoryPanel.transform, false);
-        var inventoryText = inventoryTextGO.AddComponent<Text>();
-        inventoryText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+        var gridGO = new GameObject("InventoryGrid");
+        gridGO.transform.SetParent(inventoryPanel.transform, false);
 
         var flavourTextGO = new GameObject("FlavourText");
         flavourTextGO.transform.SetParent(canvasGO.transform, false);
@@ -115,7 +114,9 @@ public static class GameSetupEditor
         promptGO.SetActive(false);
 
         var uiSO = new SerializedObject(uiManager);
-        uiSO.FindProperty("inventoryText").objectReferenceValue = inventoryText;
+        uiSO.FindProperty("inventoryContainer").objectReferenceValue = gridGO.transform;
+        uiSO.FindProperty("inventoryButtonPrefab").objectReferenceValue =
+            AssetDatabase.LoadAssetAtPath<InventoryButton>(InventoryButtonPrefabPath);
         uiSO.FindProperty("flavourText").objectReferenceValue = flavourText;
         uiSO.FindProperty("prompt").objectReferenceValue = promptGO;
         uiSO.ApplyModifiedProperties();

--- a/Assets/Editor/PrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilder.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.UI;
 
 /// <summary>
 /// Utility for generating placeholder prefabs for core systems.
@@ -21,6 +22,7 @@ public static class PrefabBuilder
         CreatePrefab<SoundManager>("SoundManager");
         CreatePrefab<UIManager>("UIManager");
         CreatePrefab<QuestManager>("QuestManager");
+        CreateInventoryButtonPrefab();
     }
 
     private static void EnsureFolder()
@@ -36,6 +38,19 @@ public static class PrefabBuilder
         var go = new GameObject(name);
         go.AddComponent<T>();
         var path = $"{PrefabFolder}/{name}.prefab";
+        PrefabUtility.SaveAsPrefabAsset(go, path);
+        Object.DestroyImmediate(go);
+    }
+
+    private static void CreateInventoryButtonPrefab()
+    {
+        var go = new GameObject("InventoryButton");
+        go.AddComponent<RectTransform>();
+        go.AddComponent<CanvasRenderer>();
+        go.AddComponent<Image>();
+        go.AddComponent<Button>();
+        go.AddComponent<InventoryButton>();
+        var path = $"{PrefabFolder}/InventoryButton.prefab";
         PrefabUtility.SaveAsPrefabAsset(go, path);
         Object.DestroyImmediate(go);
     }

--- a/Assets/Prefabs/InventoryButton.prefab
+++ b/Assets/Prefabs/InventoryButton.prefab
@@ -11,8 +11,8 @@ GameObject:
   - component: {fileID: 2856750075505989608}
   - component: {fileID: 5362526234481104625}
   - component: {fileID: 7599394058853243007}
-  - component: {fileID: 4657293504370001339}
   - component: {fileID: 1720667103602952089}
+  - component: {fileID: 3636217461802261226}
   m_Layer: 0
   m_Name: InventoryButton
   m_TagString: Untagged
@@ -57,8 +57,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -77,7 +77,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &4657293504370001339
+--- !u!114 &1720667103602952089
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -86,10 +86,32 @@ MonoBehaviour:
   m_GameObject: {fileID: 8442599107765029896}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8ef7a7524ebf7dd17b8b48475, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  m_Interactable: 1
+  m_Script: {fileID: 11500000, guid: c29da7dd199e4639869c66f0b577fe4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  item: {fileID: 0}
+  ui: {fileID: 0}
+  icon: {fileID: 0}
+  button: {fileID: 0}
+--- !u!114 &3636217461802261226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8442599107765029896}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -110,19 +132,20 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
+  m_Interactable: 1
   m_TargetGraphic: {fileID: 7599394058853243007}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
---- !u!114 &1720667103602952089
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8442599107765029896}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c29da7dd199e4639869c66f0b577fe4d, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+      m_Calls:
+      - m_Target: {fileID: 1720667103602952089}
+        m_TargetAssemblyTypeName: InventoryButton, Assembly-CSharp
+        m_MethodName: OnClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2

--- a/Assets/Prefabs/InventoryButton.prefab
+++ b/Assets/Prefabs/InventoryButton.prefab
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8442599107765029896
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2856750075505989608}
+  - component: {fileID: 5362526234481104625}
+  - component: {fileID: 7599394058853243007}
+  - component: {fileID: 4657293504370001339}
+  - component: {fileID: 1720667103602952089}
+  m_Layer: 0
+  m_Name: InventoryButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2856750075505989608
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8442599107765029896}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5362526234481104625
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8442599107765029896}
+  m_CullTransparentMesh: 1
+--- !u!114 &7599394058853243007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8442599107765029896}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4657293504370001339
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8442599107765029896}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8ef7a7524ebf7dd17b8b48475, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Interactable: 1
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_TargetGraphic: {fileID: 7599394058853243007}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1720667103602952089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8442599107765029896}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c29da7dd199e4639869c66f0b577fe4d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Prefabs/InventoryButton.prefab.meta
+++ b/Assets/Prefabs/InventoryButton.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0037356ee62c470eb98e397c3cfd6fd3
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefabs/ItemPickup.prefab
+++ b/Assets/Prefabs/ItemPickup.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 7083909586666423228}
   - component: {fileID: 5289074834795746837}
   - component: {fileID: 356119847346795356}
+  - component: {fileID: 6950539175299955143}
   m_Layer: 0
   m_Name: ItemPickup
   m_TagString: Untagged
@@ -46,7 +47,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cac07f5c4358f854bbe4d7f469d5da78, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  item: {fileID: 0}
+  item: {fileID: 11400000, guid: 6c5f059d89ea4ec45a56dc0e977ad1f1, type: 2}
 --- !u!212 &5289074834795746837
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -88,7 +89,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 2073366913, guid: 6ceed08971aaccc4aa8a891e8b130520, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -133,9 +134,9 @@ BoxCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
-    border: {x: 0.049999997, y: 0.049999997, z: 0.049999997, w: 0.049999997}
+    border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.16, y: 0.16}
+    oldSize: {x: 1, y: 1}
     newSize: {x: 0.16, y: 0.16}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -144,3 +145,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &6950539175299955143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3086841983082199787}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a2770e474213b04f818f8e2ccbb96d5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  highlightColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  outlineSize: 0.5
+  outlineShader: {fileID: 4800000, guid: e028f3e5855845a59d2faf4e7ef53b55, type: 3}

--- a/Assets/Prefabs/README.md
+++ b/Assets/Prefabs/README.md
@@ -31,9 +31,10 @@ This folder holds reusable templates for the game's interaction systems. Drop th
 ## SoundManager.prefab
 - Uses two `AudioSource` components for music and effects. Link the sources to the script fields and assign audio clips as needed.
 
-## UIManager.prefab and UICanvas.prefab
-- `UICanvas` includes sample text objects.
-- `UIManager` should reference UI elements on the canvas such as **inventoryText**, **flavourText**, and **prompt**.
+## UICanvas.prefab and InventoryButton.prefab
+- `UICanvas` contains an `InventoryPanel` with a child `InventoryGrid` where item buttons are spawned at runtime.
+- `UIManager` should reference **inventoryContainer**, **inventoryButtonPrefab**, **flavourText**, and **prompt**.
+- `InventoryButton` is a basic `Button` with an `Image` and `InventoryButton` script.
 
 ## ScriptableObjects/Items
 - Contains example `Item` assets. Duplicate `SampleItem.asset` to create new items.

--- a/Assets/Prefabs/ScriptableObjects/Items/SampleItem.asset
+++ b/Assets/Prefabs/ScriptableObjects/Items/SampleItem.asset
@@ -16,4 +16,4 @@ MonoBehaviour:
   displayName: Test Item
   description: This is just a test Item. You should not have this. It even looks
     weird.
-  sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  sprite: {fileID: 2073366913, guid: 6ceed08971aaccc4aa8a891e8b130520, type: 3}

--- a/Assets/Prefabs/UICanvas.prefab
+++ b/Assets/Prefabs/UICanvas.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &952365944994401383
+--- !u!1 &5957001495070203296
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,12 +8,12 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4543916346670627507}
-  - component: {fileID: 196758412794385343}
-  - component: {fileID: 2538514301297756856}
-  - component: {fileID: 7552057868312496659}
-  - component: {fileID: 1500538492193565734}
-  - component: {fileID: 7840596370748055043}
+  - component: {fileID: 1861359407547691780}
+  - component: {fileID: 3817913817233729614}
+  - component: {fileID: 5180754703279166348}
+  - component: {fileID: 6807570566262347708}
+  - component: {fileID: 2349624548146162056}
+  - component: {fileID: 3732311167130828911}
   m_Layer: 0
   m_Name: UICanvas
   m_TagString: Untagged
@@ -21,21 +21,21 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &4543916346670627507
+--- !u!224 &1861359407547691780
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952365944994401383}
+  m_GameObject: {fileID: 5957001495070203296}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4090847210647805248}
-  - {fileID: 7897750375283244772}
-  - {fileID: 1152007444966250682}
+  - {fileID: 7961320686357976175}
+  - {fileID: 3726961111388299781}
+  - {fileID: 380110854809208498}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -43,13 +43,13 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!223 &196758412794385343
+--- !u!223 &3817913817233729614
 Canvas:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952365944994401383}
+  m_GameObject: {fileID: 5957001495070203296}
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 0
@@ -66,18 +66,18 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &2538514301297756856
+--- !u!114 &5180754703279166348
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952365944994401383}
+  m_GameObject: {fileID: 5957001495070203296}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -89,53 +89,54 @@ MonoBehaviour:
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
   m_PresetInfoIsWorld: 0
---- !u!114 &7552057868312496659
+--- !u!114 &6807570566262347708
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952365944994401383}
+  m_GameObject: {fileID: 5957001495070203296}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &1500538492193565734
+--- !u!114 &2349624548146162056
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952365944994401383}
+  m_GameObject: {fileID: 5957001495070203296}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b6e3f88dcddf0b744bed8fa90bc17cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  inventoryText: {fileID: 4112944431996963410}
-  flavourText: {fileID: 3068253012731757683}
-  prompt: {fileID: 1531906302825528597}
---- !u!114 &7840596370748055043
+  m_Name:
+  m_EditorClassIdentifier:
+  inventoryContainer: {fileID: 1907278445462861731}
+  inventoryButtonPrefab: {fileID: 1720667103602952089, guid: 0037356ee62c470eb98e397c3cfd6fd3, type: 3}
+  flavourText: {fileID: 9194795301048139686}
+  prompt: {fileID: 8448835614338910721}
+--- !u!114 &3732311167130828911
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952365944994401383}
+  m_GameObject: {fileID: 5957001495070203296}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9e56b59de3c24a23a488f438c83cf3ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  inventoryPanel: {fileID: 2497260779594308445}
+  m_Name:
+  m_EditorClassIdentifier:
+  inventoryPanel: {fileID: 193681974378496438}
   toggleKey: 105
---- !u!1 &1531906302825528597
+--- !u!1 &193681974378496438
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -143,88 +144,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1152007444966250682}
-  - component: {fileID: 7021287561209722552}
-  - component: {fileID: 5680828562297921106}
-  m_Layer: 0
-  m_Name: Prompt
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &1152007444966250682
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1531906302825528597}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4543916346670627507}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &7021287561209722552
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1531906302825528597}
-  m_CullTransparentMesh: 1
---- !u!114 &5680828562297921106
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1531906302825528597}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 
---- !u!1 &2497260779594308445
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4090847210647805248}
-  - component: {fileID: 5129044785398467973}
-  - component: {fileID: 2463948368167767975}
+  - component: {fileID: 7961320686357976175}
+  - component: {fileID: 985768196762487770}
+  - component: {fileID: 7614380306138868928}
   m_Layer: 0
   m_Name: InventoryPanel
   m_TagString: Untagged
@@ -232,46 +154,46 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!224 &4090847210647805248
+--- !u!224 &7961320686357976175
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2497260779594308445}
+  m_GameObject: {fileID: 193681974378496438}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2718383835001284245}
-  m_Father: {fileID: 4543916346670627507}
+  - {fileID: 1907278445462861731}
+  m_Father: {fileID: 1861359407547691780}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5129044785398467973
+--- !u!222 &985768196762487770
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2497260779594308445}
+  m_GameObject: {fileID: 193681974378496438}
   m_CullTransparentMesh: 1
---- !u!114 &2463948368167767975
+--- !u!114 &7614380306138868928
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2497260779594308445}
+  m_GameObject: {fileID: 193681974378496438}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.5}
   m_RaycastTarget: 1
@@ -290,7 +212,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &5344191039525113674
+--- !u!1 &5462837367235255060
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -298,55 +220,90 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2718383835001284245}
-  - component: {fileID: 1860653975864905857}
-  - component: {fileID: 4112944431996963410}
+  - component: {fileID: 1907278445462861731}
   m_Layer: 0
-  m_Name: InventoryText
+  m_Name: InventoryGrid
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &2718383835001284245
+--- !u!224 &1907278445462861731
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5344191039525113674}
+  m_GameObject: {fileID: 5462837367235255060}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4090847210647805248}
+  m_Father: {fileID: 7961320686357976175}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4534575210078328260
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3726961111388299781}
+  - component: {fileID: 7880563150147976275}
+  - component: {fileID: 9194795301048139686}
+  m_Layer: 0
+  m_Name: FlavourText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3726961111388299781
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4534575210078328260}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1861359407547691780}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &1860653975864905857
+--- !u!222 &7880563150147976275
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5344191039525113674}
+  m_GameObject: {fileID: 4534575210078328260}
   m_CullTransparentMesh: 1
---- !u!114 &4112944431996963410
+--- !u!114 &9194795301048139686
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5344191039525113674}
+  m_GameObject: {fileID: 4534575210078328260}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -369,7 +326,7 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
---- !u!1 &7005222576637002990
+--- !u!1 &8448835614338910721
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -377,55 +334,55 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7897750375283244772}
-  - component: {fileID: 1656025448496242138}
-  - component: {fileID: 3068253012731757683}
+  - component: {fileID: 380110854809208498}
+  - component: {fileID: 6787422455616059728}
+  - component: {fileID: 5773358052348803654}
   m_Layer: 0
-  m_Name: FlavourText
+  m_Name: Prompt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7897750375283244772
+  m_IsActive: 0
+--- !u!224 &380110854809208498
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7005222576637002990}
+  m_GameObject: {fileID: 8448835614338910721}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4543916346670627507}
+  m_Father: {fileID: 1861359407547691780}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &1656025448496242138
+--- !u!222 &6787422455616059728
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7005222576637002990}
+  m_GameObject: {fileID: 8448835614338910721}
   m_CullTransparentMesh: 1
---- !u!114 &3068253012731757683
+--- !u!114 &5773358052348803654
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7005222576637002990}
+  m_GameObject: {fileID: 8448835614338910721}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1

--- a/Assets/Scripts/InventoryButton.cs
+++ b/Assets/Scripts/InventoryButton.cs
@@ -8,10 +8,10 @@ using UnityEngine.UI;
 [RequireComponent(typeof(Button), typeof(Image))]
 public class InventoryButton : MonoBehaviour
 {
-    private Item item;
-    private UIManager ui;
-    private Image icon;
-    private Button button;
+    public Item item;
+    public UIManager ui;
+    public Image icon;
+    public Button button;
 
     private void Awake()
     {
@@ -37,8 +37,8 @@ public class InventoryButton : MonoBehaviour
         }
         Debug.Log($"[InventoryButton] Initialized for {item.DisplayName}");
     }
-
-    private void OnClick()
+    
+    public void OnClick()
     {
         if (ui != null && item != null)
         {

--- a/Assets/Scripts/InventoryButton.cs
+++ b/Assets/Scripts/InventoryButton.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// UI button representing an inventory item. Displays the item's sprite and
+/// forwards click events to the UIManager for flavour text display.
+/// </summary>
+[RequireComponent(typeof(Button), typeof(Image))]
+public class InventoryButton : MonoBehaviour
+{
+    private Item item;
+    private UIManager ui;
+    private Image icon;
+    private Button button;
+
+    private void Awake()
+    {
+        icon = GetComponent<Image>();
+        button = GetComponent<Button>();
+    }
+
+    /// <summary>
+    /// Initializes the button with an item and UI manager reference.
+    /// </summary>
+    public void Initialize(Item item, UIManager ui)
+    {
+        this.item = item;
+        this.ui = ui;
+        if (icon != null)
+        {
+            icon.sprite = item.Sprite;
+        }
+        if (button != null)
+        {
+            button.onClick.RemoveAllListeners();
+            button.onClick.AddListener(OnClick);
+        }
+        Debug.Log($"[InventoryButton] Initialized for {item.DisplayName}");
+    }
+
+    private void OnClick()
+    {
+        if (ui != null && item != null)
+        {
+            Debug.Log($"[InventoryButton] {item.DisplayName} clicked");
+            ui.ShowFlavourText(item.Description);
+        }
+    }
+}

--- a/Assets/Scripts/InventoryButton.cs.meta
+++ b/Assets/Scripts/InventoryButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c29da7dd199e4639869c66f0b577fe4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/InventoryUI.cs
+++ b/Assets/Scripts/InventoryUI.cs
@@ -10,6 +10,7 @@ public class InventoryUI : MonoBehaviour
 
     private void Awake()
     {
+
         Debug.Log("[InventoryUI] Initialized");
     }
 

--- a/Assets/Scripts/InventoryUI.cs
+++ b/Assets/Scripts/InventoryUI.cs
@@ -8,11 +8,17 @@ public class InventoryUI : MonoBehaviour
     [SerializeField] private GameObject inventoryPanel;
     [SerializeField] private KeyCode toggleKey = KeyCode.I;
 
+    private void Awake()
+    {
+        Debug.Log("[InventoryUI] Initialized");
+    }
+
     private void Update()
     {
         if (Input.GetKeyDown(toggleKey) && inventoryPanel != null)
         {
             inventoryPanel.SetActive(!inventoryPanel.activeSelf);
+            Debug.Log($"[InventoryUI] Inventory panel active = {inventoryPanel.activeSelf}");
         }
     }
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -26,21 +26,25 @@ public class PlayerController : MonoBehaviour
 
     private void Awake()
     {
+        Debug.Log($"[PlayerController] Awake on {name}");
         rb = GetComponent<Rigidbody2D>();
     }
 
     private void Update()
     {
+        Debug.Log("[PlayerController] Update");
         HandleInput();
     }
 
     private void FixedUpdate()
     {
+        Debug.Log("[PlayerController] FixedUpdate");
         Move();
     }
 
     private void HandleInput()
     {
+        Debug.Log("[PlayerController] HandleInput start");
         input = Vector2.zero;
         if (Input.GetKey(KeyCode.W)) input.y += 1f;
         if (Input.GetKey(KeyCode.S)) input.y -= 1f;
@@ -56,21 +60,27 @@ public class PlayerController : MonoBehaviour
 
         if (Input.GetKeyDown(KeyCode.E) || Input.GetButtonDown("Fire1"))
         {
+            Debug.Log("[PlayerController] Interaction input detected");
             Interact();
         }
+
+        Debug.Log($"[PlayerController] HandleInput result - input: {input}, facing: {facing}, isTiptoeing: {isTiptoeing}");
     }
 
     private void Move()
     {
         float speed = isTiptoeing ? tiptoeSpeed : walkSpeed;
         rb.velocity = input.normalized * speed;
+        Debug.Log($"[PlayerController] Move - speed: {speed}, velocity: {rb.velocity}");
     }
 
     private void Interact()
     {
+        Debug.Log("[PlayerController] Interact called");
         if (nearbyPickups.Count > 0)
         {
             var pickup = nearbyPickups[0];
+            Debug.Log($"[PlayerController] Picking up {pickup.Item.DisplayName}");
             inventory.AddItem(pickup.Item);
             ui?.RefreshInventory(inventory);
             ui?.ShowFlavourText($"Picked up {pickup.Item.DisplayName}");
@@ -81,6 +91,7 @@ public class PlayerController : MonoBehaviour
         if (nearbyDoors.Count > 0)
         {
             var door = nearbyDoors[0];
+            Debug.Log($"[PlayerController] Entering door {door.name}");
             door.Enter();
             return;
         }
@@ -88,14 +99,17 @@ public class PlayerController : MonoBehaviour
         if (nearbyGhosts.Count > 0)
         {
             var ghost = nearbyGhosts[0];
+            Debug.Log($"[PlayerController] Interacting with ghost {ghost.name}");
             if (inventory.HasItem(ghost.RequiredItemId))
             {
                 var item = inventory.UseItem(ghost.RequiredItemId);
+                Debug.Log($"[PlayerController] Using {ghost.RequiredItemId} on ghost {ghost.name}");
                 ghost.TrySatisfy(item);
                 ui?.RefreshInventory(inventory);
             }
             else
             {
+                Debug.Log($"[PlayerController] Missing required item {ghost.RequiredItemId} for ghost {ghost.name}");
                 ui?.ShowFlavourText($"You need {ghost.RequiredItemId}");
             }
         }
@@ -103,50 +117,65 @@ public class PlayerController : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        Debug.Log("Collision Entered");
+        Debug.Log($"[PlayerController] OnTriggerEnter2D with {collision.name}");
         var pickup = collision.GetComponent<ItemPickup>();
         if (pickup != null && !nearbyPickups.Contains(pickup))
         {
             nearbyPickups.Add(pickup);
+            Debug.Log($"[PlayerController] Pickup {pickup.name} added to nearby list");
         }
 
         var door = collision.GetComponent<Door>();
         if (door != null && !nearbyDoors.Contains(door))
         {
             nearbyDoors.Add(door);
+            Debug.Log($"[PlayerController] Door {door.name} added to nearby list");
         }
 
         var ghost = collision.GetComponent<GhostAI>();
         if (ghost != null && !nearbyGhosts.Contains(ghost))
         {
             nearbyGhosts.Add(ghost);
+            Debug.Log($"[PlayerController] Ghost {ghost.name} added to nearby list");
         }
 
         var highlight = collision.GetComponent<IHighlightable>();
-        highlight?.SetHighlighted(true);
+        if (highlight != null)
+        {
+            Debug.Log($"[PlayerController] Highlighting {collision.name}");
+            highlight.SetHighlighted(true);
+        }
     }
 
     private void OnTriggerExit2D(Collider2D collision)
     {
+        Debug.Log($"[PlayerController] OnTriggerExit2D with {collision.name}");
         var pickup = collision.GetComponent<ItemPickup>();
         if (pickup != null)
         {
             nearbyPickups.Remove(pickup);
+            Debug.Log($"[PlayerController] Pickup {pickup.name} removed from nearby list");
         }
 
         var door = collision.GetComponent<Door>();
         if (door != null)
         {
             nearbyDoors.Remove(door);
+            Debug.Log($"[PlayerController] Door {door.name} removed from nearby list");
         }
 
         var ghost = collision.GetComponent<GhostAI>();
         if (ghost != null)
         {
             nearbyGhosts.Remove(ghost);
+            Debug.Log($"[PlayerController] Ghost {ghost.name} removed from nearby list");
         }
 
         var highlight = collision.GetComponent<IHighlightable>();
-        highlight?.SetHighlighted(false);
+        if (highlight != null)
+        {
+            Debug.Log($"[PlayerController] Removing highlight from {collision.name}");
+            highlight.SetHighlighted(false);
+        }
     }
 }

--- a/Assets/Scripts/ProximityHighlight.cs
+++ b/Assets/Scripts/ProximityHighlight.cs
@@ -7,20 +7,65 @@ using UnityEngine;
 public class ProximityHighlight : MonoBehaviour, IHighlightable
 {
     [SerializeField] private Color highlightColor = Color.yellow;
+    [SerializeField] private float outlineSize = 1f;
+    [SerializeField] private Shader outlineShader;
 
     private SpriteRenderer spriteRenderer;
-    private Color originalColor;
+    private Material originalMaterial;
+    private Material outlineMaterial;
 
     private void Awake()
     {
+        Debug.Log($"[ProximityHighlight] Awake on {name}");
         spriteRenderer = GetComponent<SpriteRenderer>();
-        originalColor = spriteRenderer.color;
+        if (spriteRenderer != null)
+        {
+            originalMaterial = spriteRenderer.material;
+        }
+        else
+        {
+            Debug.LogWarning($"[ProximityHighlight] No SpriteRenderer found on {name}");
+        }
+
+        if (outlineShader == null)
+        {
+            outlineShader = Shader.Find("Custom/Outline");
+            Debug.Log($"[ProximityHighlight] Outline shader {(outlineShader != null ? "found" : "not found")} via Shader.Find on {name}");
+        }
+
+        if (outlineShader != null)
+        {
+            outlineMaterial = new Material(outlineShader);
+            Debug.Log($"[ProximityHighlight] Outline material created for {name}");
+        }
+        else
+        {
+            Debug.LogWarning($"[ProximityHighlight] Outline shader missing for {name}, highlighting will fallback to original material");
+        }
     }
 
     /// <inheritdoc />
     public void SetHighlighted(bool highlighted)
     {
-        if (spriteRenderer == null) return;
-        spriteRenderer.color = highlighted ? highlightColor : originalColor;
+        if (spriteRenderer == null)
+        {
+            Debug.LogWarning($"[ProximityHighlight] SpriteRenderer missing on {name} when trying to set highlight");
+            return;
+        }
+
+        Debug.Log($"[ProximityHighlight] SetHighlighted({highlighted}) on {name}");
+
+        if (highlighted && outlineMaterial != null)
+        {
+            outlineMaterial.SetColor("_OutlineColor", highlightColor);
+            outlineMaterial.SetFloat("_OutlineSize", outlineSize);
+            spriteRenderer.material = outlineMaterial;
+            Debug.Log($"[ProximityHighlight] Applied outline material to {name}");
+        }
+        else
+        {
+            spriteRenderer.material = originalMaterial;
+            Debug.Log($"[ProximityHighlight] Restored original material on {name}");
+        }
     }
 }

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -7,16 +6,37 @@ using UnityEngine.UI;
 /// </summary>
 public class UIManager : MonoBehaviour
 {
-    [SerializeField] private Text inventoryText;
+    [SerializeField] private Transform inventoryContainer;
+    [SerializeField] private InventoryButton inventoryButtonPrefab;
     [SerializeField] private Text flavourText;
     [SerializeField] private GameObject prompt;
+
     /// <summary>
     /// Updates the inventory UI with current items.
     /// </summary>
     public void RefreshInventory(InventorySystem inventory)
     {
-        if (inventoryText == null || inventory == null) return;
-        inventoryText.text = string.Join(", ", inventory.GetAllItems().Select(i => i.DisplayName));
+        if (inventoryContainer == null || inventoryButtonPrefab == null || inventory == null)
+        {
+            Debug.Log("[UIManager] Missing references for inventory refresh");
+            return;
+        }
+
+        foreach (Transform child in inventoryContainer)
+        {
+            Destroy(child.gameObject);
+        }
+
+        int index = 0;
+        foreach (var item in inventory.GetAllItems())
+        {
+            var button = Instantiate(inventoryButtonPrefab, inventoryContainer);
+            var rt = button.GetComponent<RectTransform>();
+            rt.anchoredPosition = new Vector2((index % 4) * 70, -(index / 4) * 70);
+            button.Initialize(item, this);
+            Debug.Log($"[UIManager] Created button for {item.DisplayName} at index {index}");
+            index++;
+        }
     }
 
     /// <summary>
@@ -25,6 +45,7 @@ public class UIManager : MonoBehaviour
     public void ShowFlavourText(string text)
     {
         if (flavourText == null) return;
+        Debug.Log($"[UIManager] Flavour text: {text}");
         flavourText.text = text;
     }
 
@@ -35,6 +56,7 @@ public class UIManager : MonoBehaviour
     {
         if (prompt != null)
         {
+            Debug.Log($"[UIManager] Prompt visibility set to {isVisible}");
             prompt.SetActive(isVisible);
         }
     }

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce8cba3c501e4d7ab3f675885fbfb5ea
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Outline.shader
+++ b/Assets/Shaders/Outline.shader
@@ -1,0 +1,71 @@
+Shader "Custom/Outline"
+{
+    Properties
+    {
+        _MainTex ("Sprite Texture", 2D) = "white" {}
+        _OutlineColor ("Outline Color", Color) = (1,1,0,1)
+        _OutlineSize ("Outline Size", Float) = 1
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+            fixed4 _OutlineColor;
+            float _OutlineSize;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 c = tex2D(_MainTex, i.uv);
+                if (c.a == 0)
+                {
+                    float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
+                    float alpha = 0;
+                    alpha += tex2D(_MainTex, i.uv + float2(offset.x, 0)).a;
+                    alpha += tex2D(_MainTex, i.uv + float2(-offset.x, 0)).a;
+                    alpha += tex2D(_MainTex, i.uv + float2(0, offset.y)).a;
+                    alpha += tex2D(_MainTex, i.uv + float2(0, -offset.y)).a;
+                    if (alpha > 0)
+                    {
+                        return _OutlineColor;
+                    }
+                    return 0;
+                }
+                return c;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/Outline.shader.meta
+++ b/Assets/Shaders/Outline.shader.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: e028f3e5855845a59d2faf4e7ef53b55
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  validGlobalKeywords: []
+  invalidGlobalKeywords: []
+  validLocalKeywords: []
+  invalidLocalKeywords: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add new outline shader for sprite highlighting
- switch proximity highlights to shader-based outlines
- pepper player controller and highlighting code with detailed debug logs

## Testing
- no tests: Unity project without runnable dotnet tests

------
https://chatgpt.com/codex/tasks/task_e_68aa12d07a3c832f86e6f4724e056eba