### PR TITLE
feat: add random interaction responses

### DIFF
--- a/Assets/Scripts/Door.cs
+++ b/Assets/Scripts/Door.cs
@@ -11,6 +11,8 @@ public class Door : MonoBehaviour
     [SerializeField] private bool consumeItem;
     [SerializeField] private UnityEvent onOpened;
     [SerializeField] private UnityEvent onFailed;
+    [SerializeField] [TextArea] private string[] successResponses;
+    [SerializeField] [TextArea] private string[] failedResponses;
 
     private RoomManager roomManager;
 
@@ -29,7 +31,7 @@ public class Door : MonoBehaviour
             if (!inventory.HasItem(requiredItemId))
             {
                 onFailed?.Invoke();
-                ui?.ShowFlavourText($"You need {requiredItemId}");
+                ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {requiredItemId}");
                 return false;
             }
             if (consumeItem)
@@ -40,11 +42,22 @@ public class Door : MonoBehaviour
         }
 
         onOpened?.Invoke();
+        var success = GetRandomResponse(successResponses);
+        if (!string.IsNullOrEmpty(success))
+        {
+            ui?.ShowFlavourText(success);
+        }
 
         if (roomManager != null && !string.IsNullOrEmpty(targetScene))
         {
             roomManager.LoadRoom(targetScene);
         }
         return true;
+    }
+
+    private string GetRandomResponse(string[] responses)
+    {
+        if (responses == null || responses.Length == 0) return null;
+        return responses[Random.Range(0, responses.Length)];
     }
 }

--- a/Assets/Scripts/GhostAI.cs
+++ b/Assets/Scripts/GhostAI.cs
@@ -11,6 +11,8 @@ public class GhostAI : MonoBehaviour
     [SerializeField] private bool isDefeated;
     [SerializeField] private UnityEvent onDefeated;
     [SerializeField] private UnityEvent onFailed;
+    [SerializeField] [TextArea] private string[] successResponses;
+    [SerializeField] [TextArea] private string[] failedResponses;
 
     /// <summary>
     /// Item id required to clear the ghost.
@@ -28,7 +30,7 @@ public class GhostAI : MonoBehaviour
             if (!inventory.HasItem(requiredItemId))
             {
                 onFailed?.Invoke();
-                ui?.ShowFlavourText($"You need {requiredItemId}");
+                ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {requiredItemId}");
                 return false;
             }
             if (consumeItem)
@@ -40,7 +42,18 @@ public class GhostAI : MonoBehaviour
 
         isDefeated = true;
         onDefeated?.Invoke();
+        var success = GetRandomResponse(successResponses);
+        if (!string.IsNullOrEmpty(success))
+        {
+            ui?.ShowFlavourText(success);
+        }
         gameObject.SetActive(false);
         return true;
+    }
+
+    private string GetRandomResponse(string[] responses)
+    {
+        if (responses == null || responses.Length == 0) return null;
+        return responses[Random.Range(0, responses.Length)];
     }
 }

--- a/Assets/Scripts/ItemPickup.cs
+++ b/Assets/Scripts/ItemPickup.cs
@@ -11,6 +11,8 @@ public class ItemPickup : MonoBehaviour
     [SerializeField] private bool consumeItem;
     [SerializeField] private UnityEvent onPickedUp;
     [SerializeField] private UnityEvent onFailed;
+    [SerializeField] [TextArea] private string[] successResponses;
+    [SerializeField] [TextArea] private string[] failedResponses;
 
     /// <summary>
     /// The item granted when picked up.
@@ -27,7 +29,7 @@ public class ItemPickup : MonoBehaviour
             if (!inventory.HasItem(requiredItemId))
             {
                 onFailed?.Invoke();
-                ui?.ShowFlavourText($"You need {requiredItemId}");
+                ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {requiredItemId}");
                 return false;
             }
             if (consumeItem)
@@ -39,9 +41,15 @@ public class ItemPickup : MonoBehaviour
 
         inventory.AddItem(item);
         ui?.RefreshInventory(inventory);
-        ui?.ShowFlavourText($"Picked up {item.DisplayName}");
+        ui?.ShowFlavourText(GetRandomResponse(successResponses) ?? $"Picked up {item.DisplayName}");
         onPickedUp?.Invoke();
         Destroy(gameObject);
         return true;
+    }
+
+    private string GetRandomResponse(string[] responses)
+    {
+        if (responses == null || responses.Length == 0) return null;
+        return responses[Random.Range(0, responses.Length)];
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring multiple success and failure responses for interactable items, doors, and ghosts
- randomly select a response when interactions succeed or fail

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4c2bb910832fa35dde91e624c7c6