### PR TITLE
Add typewriter text effects and multi-item interactions

### DIFF
--- a/Assets/Prefabs/Ghost.prefab
+++ b/Assets/Prefabs/Ghost.prefab
@@ -44,5 +44,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5bcce89a542cf2a418ee1d6e6e17be8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  requiredItemId: 
+  requiredItemIds: []
   isDefeated: 0

--- a/Assets/Prefabs/UICanvas.prefab
+++ b/Assets/Prefabs/UICanvas.prefab
@@ -455,7 +455,7 @@ MonoBehaviour:
   inventoryContainer: {fileID: 1907278445462861731}
   inventoryButtonPrefab: {fileID: 1720667103602952089, guid: 0037356ee62c470eb98e397c3cfd6fd3, type: 3}
   flavourText: {fileID: 0}
-  prompt: {fileID: 8448835614338910721}
+  prompt: {fileID: 0}
   inventory: {fileID: 0}
 --- !u!114 &3732311167130828911
 MonoBehaviour:

--- a/Assets/Scenes/Prefab Garage.unity
+++ b/Assets/Scenes/Prefab Garage.unity
@@ -182,7 +182,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   targetScene: Kitchen
-  requiredItemId: 9999
+  requiredItemIds:
+  - 9999
   consumeItem: 0
   onOpened:
     m_PersistentCalls:

--- a/Assets/Scripts/Door.cs
+++ b/Assets/Scripts/Door.cs
@@ -7,7 +7,7 @@ using UnityEngine.Events;
 public class Door : MonoBehaviour
 {
     [SerializeField] private string targetScene;
-    [SerializeField] private string requiredItemId;
+    [SerializeField] private string[] requiredItemIds;
     [SerializeField] private bool consumeItem;
     [SerializeField] private UnityEvent onOpened;
     [SerializeField] private UnityEvent onFailed;
@@ -26,17 +26,23 @@ public class Door : MonoBehaviour
     /// </summary>
     public bool Interact(InventorySystem inventory, UIManager ui)
     {
-        if (!string.IsNullOrEmpty(requiredItemId))
+        if (requiredItemIds != null && requiredItemIds.Length > 0)
         {
-            if (!inventory.HasItem(requiredItemId))
+            foreach (var id in requiredItemIds)
             {
-                onFailed?.Invoke();
-                ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {requiredItemId}");
-                return false;
+                if (!inventory.HasItem(id))
+                {
+                    onFailed?.Invoke();
+                    ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {string.Join(", ", requiredItemIds)}");
+                    return false;
+                }
             }
             if (consumeItem)
             {
-                inventory.UseItem(requiredItemId);
+                foreach (var id in requiredItemIds)
+                {
+                    inventory.UseItem(id);
+                }
                 ui?.RefreshInventory(inventory);
             }
         }

--- a/Assets/Scripts/GhostAI.cs
+++ b/Assets/Scripts/GhostAI.cs
@@ -6,7 +6,7 @@ using UnityEngine.Events;
 /// </summary>
 public class GhostAI : MonoBehaviour
 {
-    [SerializeField] private string requiredItemId;
+    [SerializeField] private string[] requiredItemIds;
     [SerializeField] private bool consumeItem = true;
     [SerializeField] private bool isDefeated;
     [SerializeField] private UnityEvent onDefeated;
@@ -15,9 +15,9 @@ public class GhostAI : MonoBehaviour
     [SerializeField] [TextArea] private string[] failedResponses;
 
     /// <summary>
-    /// Item id required to clear the ghost.
+    /// Item ids required to clear the ghost.
     /// </summary>
-    public string RequiredItemId => requiredItemId;
+    public string[] RequiredItemIds => requiredItemIds;
 
     /// <summary>
     /// Attempts to interact with the ghost using the player's inventory.
@@ -25,17 +25,23 @@ public class GhostAI : MonoBehaviour
     public bool Interact(InventorySystem inventory, UIManager ui)
     {
         if (isDefeated) return false;
-        if (!string.IsNullOrEmpty(requiredItemId))
+        if (requiredItemIds != null && requiredItemIds.Length > 0)
         {
-            if (!inventory.HasItem(requiredItemId))
+            foreach (var id in requiredItemIds)
             {
-                onFailed?.Invoke();
-                ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {requiredItemId}");
-                return false;
+                if (!inventory.HasItem(id))
+                {
+                    onFailed?.Invoke();
+                    ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {string.Join(", ", requiredItemIds)}");
+                    return false;
+                }
             }
             if (consumeItem)
             {
-                inventory.UseItem(requiredItemId);
+                foreach (var id in requiredItemIds)
+                {
+                    inventory.UseItem(id);
+                }
                 ui?.RefreshInventory(inventory);
             }
         }

--- a/Assets/Scripts/InventoryButton.cs
+++ b/Assets/Scripts/InventoryButton.cs
@@ -37,14 +37,12 @@ public class InventoryButton : MonoBehaviour
             button.onClick.RemoveAllListeners();
             button.onClick.AddListener(OnClick);
         }
-        Debug.Log($"[InventoryButton] Initialized for {item.DisplayName}");
     }
 
     private void OnClick()
     {
         if (ui != null && item != null)
         {
-            Debug.Log($"[InventoryButton] {item.DisplayName} clicked");
             ui.ShowFlavourText(item.Description);
         }
     }

--- a/Assets/Scripts/InventorySystem.cs
+++ b/Assets/Scripts/InventorySystem.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 /// </summary>
 public class InventorySystem : MonoBehaviour
 {
-    private readonly Dictionary<string, Item> items = new();
+    private readonly Dictionary<string, Item> items = new Dictionary<string, Item>();
 
     /// <summary>
     /// Raised when an item is added to the inventory.
@@ -25,11 +25,9 @@ public class InventorySystem : MonoBehaviour
     {
         if (item == null || items.ContainsKey(item.Id))
         {
-            Debug.Log($"[InventorySystem] AddItem ignored for {item?.DisplayName ?? "null"}");
             return;
         }
         items[item.Id] = item;
-        Debug.Log($"[InventorySystem] Added {item.DisplayName}");
         ItemAdded?.Invoke(item);
     }
 
@@ -38,9 +36,7 @@ public class InventorySystem : MonoBehaviour
     /// </summary>
     public bool HasItem(string id)
     {
-        bool has = items.ContainsKey(id);
-        Debug.Log($"[InventorySystem] HasItem {id} = {has}");
-        return has;
+        return items.ContainsKey(id);
     }
 
     /// <summary>
@@ -50,11 +46,9 @@ public class InventorySystem : MonoBehaviour
     {
         if (!items.TryGetValue(id, out var item))
         {
-            Debug.Log($"[InventorySystem] RemoveItem failed for {id}");
             return false;
         }
         items.Remove(id);
-        Debug.Log($"[InventorySystem] Removed {item.DisplayName}");
         ItemRemoved?.Invoke(item);
         return true;
     }
@@ -66,11 +60,9 @@ public class InventorySystem : MonoBehaviour
     {
         if (!items.TryGetValue(id, out var item))
         {
-            Debug.Log($"[InventorySystem] UseItem failed for {id}");
             return null;
         }
         items.Remove(id);
-        Debug.Log($"[InventorySystem] Used {item.DisplayName}");
         ItemRemoved?.Invoke(item);
         return item;
     }
@@ -80,7 +72,6 @@ public class InventorySystem : MonoBehaviour
     /// </summary>
     public IEnumerable<Item> GetAllItems()
     {
-        Debug.Log($"[InventorySystem] GetAllItems count = {items.Count}");
         return items.Values;
     }
 }

--- a/Assets/Scripts/InventoryUI.cs
+++ b/Assets/Scripts/InventoryUI.cs
@@ -9,18 +9,12 @@ public class InventoryUI : MonoBehaviour
     [SerializeField] private KeyCode toggleKey = KeyCode.I;
     [SerializeField] private UIManager ui;
 
-    private void Awake()
-    {
-        Debug.Log("[InventoryUI] Initialized");
-    }
-
     private void Update()
     {
         if (Input.GetKeyDown(toggleKey) && inventoryPanel != null)
         {
             bool newActive = !inventoryPanel.activeSelf;
             inventoryPanel.SetActive(newActive);
-            Debug.Log($"[InventoryUI] Inventory panel active = {inventoryPanel.activeSelf}");
             if (newActive)
             {
                 ui?.RefreshInventory();

--- a/Assets/Scripts/ItemPickup.cs
+++ b/Assets/Scripts/ItemPickup.cs
@@ -7,7 +7,7 @@ using UnityEngine.Events;
 public class ItemPickup : MonoBehaviour
 {
     [SerializeField] private Item item;
-    [SerializeField] private string requiredItemId;
+    [SerializeField] private string[] requiredItemIds;
     [SerializeField] private bool consumeItem;
     [SerializeField] private UnityEvent onPickedUp;
     [SerializeField] private UnityEvent onFailed;
@@ -24,17 +24,23 @@ public class ItemPickup : MonoBehaviour
     /// </summary>
     public bool Interact(InventorySystem inventory, UIManager ui)
     {
-        if (!string.IsNullOrEmpty(requiredItemId))
+        if (requiredItemIds != null && requiredItemIds.Length > 0)
         {
-            if (!inventory.HasItem(requiredItemId))
+            foreach (var id in requiredItemIds)
             {
-                onFailed?.Invoke();
-                ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {requiredItemId}");
-                return false;
+                if (!inventory.HasItem(id))
+                {
+                    onFailed?.Invoke();
+                    ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {string.Join(", ", requiredItemIds)}");
+                    return false;
+                }
             }
             if (consumeItem)
             {
-                inventory.UseItem(requiredItemId);
+                foreach (var id in requiredItemIds)
+                {
+                    inventory.UseItem(id);
+                }
                 ui?.RefreshInventory(inventory);
             }
         }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -20,31 +20,27 @@ public class PlayerController : MonoBehaviour
     private Vector2 facing = Vector2.down;
     private bool isTiptoeing;
 
-    public List<ItemPickup> nearbyPickups = new();
-    public readonly List<GhostAI> nearbyGhosts = new();
-    public readonly List<Door> nearbyDoors = new();
+    public List<ItemPickup> nearbyPickups = new List<ItemPickup>();
+    public readonly List<GhostAI> nearbyGhosts = new List<GhostAI>();
+    public readonly List<Door> nearbyDoors = new List<Door>();
 
     private void Awake()
     {
-        Debug.Log($"[PlayerController] Awake on {name}");
         rb = GetComponent<Rigidbody2D>();
     }
 
     private void Update()
     {
-        Debug.Log("[PlayerController] Update");
         HandleInput();
     }
 
     private void FixedUpdate()
     {
-        Debug.Log("[PlayerController] FixedUpdate");
         Move();
     }
 
     private void HandleInput()
     {
-        Debug.Log("[PlayerController] HandleInput start");
         input = Vector2.zero;
         if (Input.GetKey(KeyCode.W)) input.y += 1f;
         if (Input.GetKey(KeyCode.S)) input.y -= 1f;
@@ -60,27 +56,21 @@ public class PlayerController : MonoBehaviour
 
         if (Input.GetKeyDown(KeyCode.E) || Input.GetButtonDown("Fire1"))
         {
-            Debug.Log("[PlayerController] Interaction input detected");
             Interact();
         }
-
-        Debug.Log($"[PlayerController] HandleInput result - input: {input}, facing: {facing}, isTiptoeing: {isTiptoeing}");
     }
 
     private void Move()
     {
         float speed = isTiptoeing ? tiptoeSpeed : walkSpeed;
         rb.velocity = input.normalized * speed;
-        Debug.Log($"[PlayerController] Move - speed: {speed}, velocity: {rb.velocity}");
     }
 
     private void Interact()
     {
-        Debug.Log("[PlayerController] Interact called");
         if (nearbyPickups.Count > 0)
         {
             var pickup = nearbyPickups[0];
-            Debug.Log($"[PlayerController] Interacting with pickup {pickup.name}");
             pickup.Interact(inventory, ui);
             return;
         }
@@ -88,7 +78,6 @@ public class PlayerController : MonoBehaviour
         if (nearbyDoors.Count > 0)
         {
             var door = nearbyDoors[0];
-            Debug.Log($"[PlayerController] Interacting with door {door.name}");
             door.Interact(inventory, ui);
             return;
         }
@@ -96,71 +85,60 @@ public class PlayerController : MonoBehaviour
         if (nearbyGhosts.Count > 0)
         {
             var ghost = nearbyGhosts[0];
-            Debug.Log($"[PlayerController] Interacting with ghost {ghost.name}");
             ghost.Interact(inventory, ui);
         }
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        Debug.Log($"[PlayerController] OnTriggerEnter2D with {collision.name}");
         var pickup = collision.GetComponent<ItemPickup>();
         if (pickup != null && !nearbyPickups.Contains(pickup))
         {
             nearbyPickups.Add(pickup);
-            Debug.Log($"[PlayerController] Pickup {pickup.name} added to nearby list");
         }
 
         var door = collision.GetComponent<Door>();
         if (door != null && !nearbyDoors.Contains(door))
         {
             nearbyDoors.Add(door);
-            Debug.Log($"[PlayerController] Door {door.name} added to nearby list");
         }
 
         var ghost = collision.GetComponent<GhostAI>();
         if (ghost != null && !nearbyGhosts.Contains(ghost))
         {
             nearbyGhosts.Add(ghost);
-            Debug.Log($"[PlayerController] Ghost {ghost.name} added to nearby list");
         }
 
         var highlight = collision.GetComponent<IHighlightable>();
         if (highlight != null)
         {
-            Debug.Log($"[PlayerController] Highlighting {collision.name}");
             highlight.SetHighlighted(true);
         }
     }
 
     private void OnTriggerExit2D(Collider2D collision)
     {
-        Debug.Log($"[PlayerController] OnTriggerExit2D with {collision.name}");
         var pickup = collision.GetComponent<ItemPickup>();
         if (pickup != null)
         {
             nearbyPickups.Remove(pickup);
-            Debug.Log($"[PlayerController] Pickup {pickup.name} removed from nearby list");
         }
 
         var door = collision.GetComponent<Door>();
         if (door != null)
         {
             nearbyDoors.Remove(door);
-            Debug.Log($"[PlayerController] Door {door.name} removed from nearby list");
         }
 
         var ghost = collision.GetComponent<GhostAI>();
         if (ghost != null)
         {
             nearbyGhosts.Remove(ghost);
-            Debug.Log($"[PlayerController] Ghost {ghost.name} removed from nearby list");
         }
 
         var highlight = collision.GetComponent<IHighlightable>();
         if (highlight != null)
         {
-            Debug.Log($"[PlayerController] Removing highlight from {collision.name}");
             highlight.SetHighlighted(false);
         }
     }

--- a/Assets/Scripts/ProximityHighlight.cs
+++ b/Assets/Scripts/ProximityHighlight.cs
@@ -16,7 +16,6 @@ public class ProximityHighlight : MonoBehaviour, IHighlightable
 
     private void Awake()
     {
-        Debug.Log($"[ProximityHighlight] Awake on {name}");
         spriteRenderer = GetComponent<SpriteRenderer>();
         if (spriteRenderer != null)
         {
@@ -24,23 +23,21 @@ public class ProximityHighlight : MonoBehaviour, IHighlightable
         }
         else
         {
-            Debug.LogWarning($"[ProximityHighlight] No SpriteRenderer found on {name}");
+            Debug.LogWarning($"No SpriteRenderer found on {name}");
         }
 
         if (outlineShader == null)
         {
             outlineShader = Shader.Find("Custom/Outline");
-            Debug.Log($"[ProximityHighlight] Outline shader {(outlineShader != null ? "found" : "not found")} via Shader.Find on {name}");
         }
 
         if (outlineShader != null)
         {
             outlineMaterial = new Material(outlineShader);
-            Debug.Log($"[ProximityHighlight] Outline material created for {name}");
         }
         else
         {
-            Debug.LogWarning($"[ProximityHighlight] Outline shader missing for {name}, highlighting will fallback to original material");
+            Debug.LogWarning($"Outline shader missing for {name}, highlighting will fallback to original material");
         }
     }
 
@@ -49,23 +46,19 @@ public class ProximityHighlight : MonoBehaviour, IHighlightable
     {
         if (spriteRenderer == null)
         {
-            Debug.LogWarning($"[ProximityHighlight] SpriteRenderer missing on {name} when trying to set highlight");
+            Debug.LogWarning($"SpriteRenderer missing on {name} when trying to set highlight");
             return;
         }
-
-        Debug.Log($"[ProximityHighlight] SetHighlighted({highlighted}) on {name}");
 
         if (highlighted && outlineMaterial != null)
         {
             outlineMaterial.SetColor("_OutlineColor", highlightColor);
             outlineMaterial.SetFloat("_OutlineSize", outlineSize);
             spriteRenderer.material = outlineMaterial;
-            Debug.Log($"[ProximityHighlight] Applied outline material to {name}");
         }
         else
         {
             spriteRenderer.material = originalMaterial;
-            Debug.Log($"[ProximityHighlight] Restored original material on {name}");
         }
     }
 }

--- a/Assets/Scripts/TypewriterText.cs
+++ b/Assets/Scripts/TypewriterText.cs
@@ -1,0 +1,193 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+/// <summary>
+/// Displays text with a typewriter effect and optional vertex animations defined by inline tags.
+/// Supports <c><jitter></c> and <c><float></c> tags and fades out after a delay.
+/// </summary>
+[RequireComponent(typeof(CanvasGroup))]
+public class TypewriterText : MonoBehaviour
+{
+    [SerializeField] private TMP_Text textComponent;
+    [SerializeField] private float charactersPerSecond = 40f;
+    [SerializeField] private float fadeDelay = 2f;
+    [SerializeField] private float fadeDuration = 1f;
+    [SerializeField] private float jitterAmount = 0.5f;
+    [SerializeField] private float floatAmplitude = 2f;
+    [SerializeField] private float floatFrequency = 2f;
+
+    private CanvasGroup canvasGroup;
+    private readonly List<EffectRange> effects = new List<EffectRange>();
+    private TMP_MeshInfo[] originalMeshInfo;
+    private bool isAnimating;
+
+    private enum EffectType { Jitter, Float }
+
+    private struct EffectRange
+    {
+        public int start;
+        public int end;
+        public EffectType type;
+    }
+
+    private void Awake()
+    {
+        if (textComponent == null)
+        {
+            textComponent = GetComponentInChildren<TMP_Text>();
+        }
+        canvasGroup = GetComponent<CanvasGroup>();
+        gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Shows the provided text with effects, restarting any existing animation.
+    /// </summary>
+    public void Show(string source)
+    {
+        StopAllCoroutines();
+        ParseEffects(source, out var plainText);
+        gameObject.SetActive(true);
+        textComponent.text = plainText;
+        textComponent.maxVisibleCharacters = 0;
+        textComponent.ForceMeshUpdate();
+        originalMeshInfo = textComponent.textInfo.CopyMeshInfoVertexData();
+        canvasGroup.alpha = 1f;
+        isAnimating = true;
+        StartCoroutine(TypeRoutine());
+    }
+
+    /// <summary>
+    /// Hides the text immediately.
+    /// </summary>
+    public void Hide()
+    {
+        StopAllCoroutines();
+        isAnimating = false;
+        gameObject.SetActive(false);
+    }
+
+    private IEnumerator TypeRoutine()
+    {
+        int total = textComponent.textInfo.characterCount;
+        for (int i = 0; i <= total; i++)
+        {
+            textComponent.maxVisibleCharacters = i;
+            yield return new WaitForSeconds(1f / charactersPerSecond);
+        }
+        yield return new WaitForSeconds(fadeDelay);
+        yield return FadeOut();
+        isAnimating = false;
+    }
+
+    private IEnumerator FadeOut()
+    {
+        float t = 0f;
+        while (t < fadeDuration)
+        {
+            canvasGroup.alpha = Mathf.Lerp(1f, 0f, t / fadeDuration);
+            t += Time.deltaTime;
+            yield return null;
+        }
+        canvasGroup.alpha = 0f;
+        gameObject.SetActive(false);
+    }
+
+    private void ParseEffects(string input, out string plain)
+    {
+        effects.Clear();
+        plain = string.Empty;
+        int plainIndex = 0;
+        var stack = new Stack<(EffectType type, int start)>();
+        for (int i = 0; i < input.Length; i++)
+        {
+            if (input[i] == '<')
+            {
+                int end = input.IndexOf('>', i);
+                if (end != -1)
+                {
+                    string tag = input.Substring(i + 1, end - i - 1).ToLower();
+                    if (tag == "jitter" || tag == "float")
+                    {
+                        stack.Push((tag == "jitter" ? EffectType.Jitter : EffectType.Float, plainIndex));
+                        i = end;
+                        continue;
+                    }
+                    else if (tag == "/jitter" || tag == "/float")
+                    {
+                        if (stack.Count > 0)
+                        {
+                            var (type, start) = stack.Pop();
+                            effects.Add(new EffectRange { start = start, end = plainIndex, type = type });
+                        }
+                        i = end;
+                        continue;
+                    }
+                }
+            }
+            plain += input[i];
+            plainIndex++;
+        }
+        while (stack.Count > 0)
+        {
+            var (type, start) = stack.Pop();
+            effects.Add(new EffectRange { start = start, end = plainIndex, type = type });
+        }
+    }
+
+    private void LateUpdate()
+    {
+        if (!isAnimating || effects.Count == 0)
+            return;
+
+        textComponent.ForceMeshUpdate();
+        var textInfo = textComponent.textInfo;
+
+        for (int i = 0; i < textInfo.meshInfo.Length; i++)
+        {
+            var dst = textInfo.meshInfo[i].vertices;
+            var src = originalMeshInfo[i].vertices;
+            System.Array.Copy(src, dst, src.Length);
+        }
+
+        float time = Time.time;
+
+        foreach (var effect in effects)
+        {
+            for (int i = effect.start; i < effect.end && i < textComponent.maxVisibleCharacters; i++)
+            {
+                var charInfo = textInfo.characterInfo[i];
+                if (!charInfo.isVisible) continue;
+
+                int materialIndex = charInfo.materialReferenceIndex;
+                int vertexIndex = charInfo.vertexIndex;
+
+                Vector3 offset = Vector3.zero;
+                switch (effect.type)
+                {
+                    case EffectType.Jitter:
+                        offset = (Vector3)Random.insideUnitCircle * jitterAmount;
+                        break;
+                    case EffectType.Float:
+                        offset = new Vector3(0, Mathf.Sin(time * floatFrequency + i) * floatAmplitude, 0);
+                        break;
+                }
+
+                var vertices = textInfo.meshInfo[materialIndex].vertices;
+                vertices[vertexIndex + 0] += offset;
+                vertices[vertexIndex + 1] += offset;
+                vertices[vertexIndex + 2] += offset;
+                vertices[vertexIndex + 3] += offset;
+            }
+        }
+
+        for (int i = 0; i < textInfo.meshInfo.Length; i++)
+        {
+            var meshInfo = textInfo.meshInfo[i];
+            meshInfo.mesh.vertices = meshInfo.vertices;
+            textComponent.UpdateGeometry(meshInfo.mesh, i);
+        }
+    }
+}

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -1,6 +1,4 @@
 using UnityEngine;
-using TMPro;
-
 /// <summary>
 /// Displays inventory, flavour text, and interaction prompts.
 /// </summary>
@@ -8,8 +6,8 @@ public class UIManager : MonoBehaviour
 {
     [SerializeField] private Transform inventoryContainer;
     [SerializeField] private InventoryButton inventoryButtonPrefab;
-    [SerializeField] private TMP_Text flavourText;
-    [SerializeField] private GameObject prompt;
+    [SerializeField] private TypewriterText flavourText;
+    [SerializeField] private TypewriterText prompt;
     [SerializeField] private InventorySystem inventory;
 
     private void Awake()
@@ -22,12 +20,11 @@ public class UIManager : MonoBehaviour
         {
             inventory.ItemAdded += OnInventoryChanged;
             inventory.ItemRemoved += OnInventoryChanged;
-            Debug.Log("[UIManager] Bound to InventorySystem and subscribed to events");
             RefreshInventory(inventory);
         }
         else
         {
-            Debug.LogWarning("[UIManager] No InventorySystem found");
+            Debug.LogWarning("No InventorySystem found");
         }
     }
 
@@ -37,13 +34,11 @@ public class UIManager : MonoBehaviour
         {
             inventory.ItemAdded -= OnInventoryChanged;
             inventory.ItemRemoved -= OnInventoryChanged;
-            Debug.Log("[UIManager] Unsubscribed from InventorySystem events");
         }
     }
 
     private void OnInventoryChanged(Item item)
     {
-        Debug.Log($"[UIManager] Inventory changed due to {item.DisplayName}");
         RefreshInventory();
     }
 
@@ -59,7 +54,6 @@ public class UIManager : MonoBehaviour
 
         if (inventoryContainer == null || inventoryButtonPrefab == null || inventory == null)
         {
-            Debug.Log("[UIManager] Missing references for inventory refresh");
             return;
         }
 
@@ -75,7 +69,6 @@ public class UIManager : MonoBehaviour
             var rt = button.GetComponent<RectTransform>();
             rt.anchoredPosition = new Vector2((index % 4) * 70, -(index / 4) * 70);
             button.Initialize(item, this);
-            Debug.Log($"[UIManager] Created button for {item.DisplayName} at index {index}");
             index++;
         }
     }
@@ -85,20 +78,22 @@ public class UIManager : MonoBehaviour
     /// </summary>
     public void ShowFlavourText(string text)
     {
-        if (flavourText == null) return;
-        Debug.Log($"[UIManager] Flavour text: {text}");
-        flavourText.text = text;
+        flavourText?.Show(text);
     }
 
     /// <summary>
-    /// Shows or hides an interaction prompt.
+    /// Shows an interaction prompt.
     /// </summary>
-    public void TogglePrompt(bool isVisible)
+    public void ShowPrompt(string text)
     {
-        if (prompt != null)
-        {
-            Debug.Log($"[UIManager] Prompt visibility set to {isVisible}");
-            prompt.SetActive(isVisible);
-        }
+        prompt?.Show(text);
+    }
+
+    /// <summary>
+    /// Hides the interaction prompt immediately.
+    /// </summary>
+    public void HidePrompt()
+    {
+        prompt?.Hide();
     }
 }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Located in `Assets/Editor/`, this editor utility generates placeholder prefabs f
 The gameplay loop revolves around several small systems that communicate through trigger collisions and shared references:
 
 1. **Item collection** – `PlayerController` gathers nearby `ItemPickup` objects and stores their `Item` in the `InventorySystem`, prompting the `UIManager` to refresh its display.
-2. **Ghost encounters** – pressing the interact key near a `GhostAI` checks the inventory for the ghost's `requiredItemId`. If found, `GhostAI` fires `onDefeated` events and hides the ghost.
+2. **Ghost encounters** – pressing the interact key near a `GhostAI` checks the inventory for any required items. If all are present, `GhostAI` fires `onDefeated` events and hides the ghost.
 3. **Room transitions** – `RoomManager` loads new scenes and applies ambience by calling the `SoundManager` and adjusting lighting.
 
 ## Prefab Setup


### PR DESCRIPTION
## Summary
- add `TypewriterText` component for typewriter display, inline `<jitter>`/`<float>` tags, and fade-out
- use typewriter component for flavour text and prompts
- allow doors, item pickups, and ghosts to require multiple inventory items
- trim excessive debug logging
- ensure typewriter text initializes correctly when re-activated

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5abcd764832fa6e7625205b08ef1