### PR TITLE
Persist inventory and UI across scenes via singleton pattern

### DIFF
--- a/Assets/Prefabs/README.md
+++ b/Assets/Prefabs/README.md
@@ -4,7 +4,6 @@ This folder holds reusable templates for the game's interaction systems. Drop th
 
 ## Player.prefab
 - Components: `Rigidbody2D`, `BoxCollider2D`, `PlayerController`, `ScaleWithDepth`.
-- Assign the `InventorySystem` and `UIManager` references on `PlayerController`.
 - The collider should remain non-trigger so it can detect trigger colliders on interactables.
 
 ## ItemPickup.prefab
@@ -17,7 +16,7 @@ This folder holds reusable templates for the game's interaction systems. Drop th
 - Fill in **Required Item Id** and optionally hook UnityEvents to **On Defeated**.
 
 ## InventorySystem.prefab
-- Holds the `InventorySystem` component. Keep one instance in the scene and reference it from the player and UI.
+- Holds the `InventorySystem` component. A single instance persists across scenes and is accessed via `InventorySystem.Instance`.
 
 ## RoomManager.prefab
 - Provides `RoomManager`. Populate the **Rooms** array with ambience settings and link a `SoundManager`.

--- a/Assets/Scripts/Door.cs
+++ b/Assets/Scripts/Door.cs
@@ -24,13 +24,16 @@ public class Door : MonoBehaviour
     /// <summary>
     /// Attempts to open the door using the player's inventory.
     /// </summary>
-    public bool Interact(InventorySystem inventory, UIManager ui)
+    public bool Interact()
     {
+        var inventory = InventorySystem.Instance;
+        var ui = UIManager.Instance;
+
         if (requiredItemIds != null && requiredItemIds.Length > 0)
         {
             foreach (var id in requiredItemIds)
             {
-                if (!inventory.HasItem(id))
+                if (inventory == null || !inventory.HasItem(id))
                 {
                     onFailed?.Invoke();
                     ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {string.Join(", ", requiredItemIds)}");
@@ -41,7 +44,7 @@ public class Door : MonoBehaviour
             {
                 foreach (var id in requiredItemIds)
                 {
-                    inventory.UseItem(id);
+                    inventory?.UseItem(id);
                 }
                 ui?.RefreshInventory(inventory);
             }

--- a/Assets/Scripts/GhostAI.cs
+++ b/Assets/Scripts/GhostAI.cs
@@ -22,14 +22,16 @@ public class GhostAI : MonoBehaviour
     /// <summary>
     /// Attempts to interact with the ghost using the player's inventory.
     /// </summary>
-    public bool Interact(InventorySystem inventory, UIManager ui)
+    public bool Interact()
     {
         if (isDefeated) return false;
+        var inventory = InventorySystem.Instance;
+        var ui = UIManager.Instance;
         if (requiredItemIds != null && requiredItemIds.Length > 0)
         {
             foreach (var id in requiredItemIds)
             {
-                if (!inventory.HasItem(id))
+                if (inventory == null || !inventory.HasItem(id))
                 {
                     onFailed?.Invoke();
                     ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {string.Join(", ", requiredItemIds)}");
@@ -40,7 +42,7 @@ public class GhostAI : MonoBehaviour
             {
                 foreach (var id in requiredItemIds)
                 {
-                    inventory.UseItem(id);
+                    inventory?.UseItem(id);
                 }
                 ui?.RefreshInventory(inventory);
             }

--- a/Assets/Scripts/InventoryButton.cs
+++ b/Assets/Scripts/InventoryButton.cs
@@ -9,7 +9,6 @@ using UnityEngine.UI;
 public class InventoryButton : MonoBehaviour
 {
     public Item item;
-    public UIManager ui;
     public Image icon;
     public Button button;
 
@@ -22,12 +21,11 @@ public class InventoryButton : MonoBehaviour
     }
 
     /// <summary>
-    /// Initializes the button with an item and UI manager reference.
+    /// Initializes the button with an item.
     /// </summary>
-    public void Initialize(Item item, UIManager ui)
+    public void Initialize(Item item)
     {
         this.item = item;
-        this.ui = ui;
         if (icon != null)
         {
             icon.sprite = item.Sprite;
@@ -41,9 +39,9 @@ public class InventoryButton : MonoBehaviour
 
     private void OnClick()
     {
-        if (ui != null && item != null)
+        if (item != null)
         {
-            ui.ShowFlavourText(item.Description);
+            UIManager.Instance?.ShowFlavourText(item.Description);
         }
     }
 }

--- a/Assets/Scripts/InventorySystem.cs
+++ b/Assets/Scripts/InventorySystem.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 /// <summary>
 /// Stores collected items and provides usage checks.
 /// </summary>
-public class InventorySystem : MonoBehaviour
+public class InventorySystem : PersistentSingleton<InventorySystem>
 {
     private readonly Dictionary<string, Item> items = new Dictionary<string, Item>();
 

--- a/Assets/Scripts/InventoryUI.cs
+++ b/Assets/Scripts/InventoryUI.cs
@@ -3,11 +3,19 @@ using UnityEngine;
 /// <summary>
 /// Toggles the inventory panel when the player presses a key.
 /// </summary>
-public class InventoryUI : MonoBehaviour
+public class InventoryUI : PersistentSingleton<InventoryUI>
 {
     [SerializeField] private GameObject inventoryPanel;
     [SerializeField] private KeyCode toggleKey = KeyCode.I;
-    [SerializeField] private UIManager ui;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        if (Instance != this)
+        {
+            return;
+        }
+    }
 
     private void Update()
     {
@@ -17,7 +25,7 @@ public class InventoryUI : MonoBehaviour
             inventoryPanel.SetActive(newActive);
             if (newActive)
             {
-                ui?.RefreshInventory();
+                UIManager.Instance?.RefreshInventory();
             }
         }
     }

--- a/Assets/Scripts/ItemPickup.cs
+++ b/Assets/Scripts/ItemPickup.cs
@@ -22,13 +22,15 @@ public class ItemPickup : MonoBehaviour
     /// <summary>
     /// Attempts to pick up the item using the player's inventory.
     /// </summary>
-    public bool Interact(InventorySystem inventory, UIManager ui)
+    public bool Interact()
     {
+        var inventory = InventorySystem.Instance;
+        var ui = UIManager.Instance;
         if (requiredItemIds != null && requiredItemIds.Length > 0)
         {
             foreach (var id in requiredItemIds)
             {
-                if (!inventory.HasItem(id))
+                if (inventory == null || !inventory.HasItem(id))
                 {
                     onFailed?.Invoke();
                     ui?.ShowFlavourText(GetRandomResponse(failedResponses) ?? $"You need {string.Join(", ", requiredItemIds)}");
@@ -39,13 +41,13 @@ public class ItemPickup : MonoBehaviour
             {
                 foreach (var id in requiredItemIds)
                 {
-                    inventory.UseItem(id);
+                    inventory?.UseItem(id);
                 }
                 ui?.RefreshInventory(inventory);
             }
         }
 
-        inventory.AddItem(item);
+        inventory?.AddItem(item);
         ui?.RefreshInventory(inventory);
         ui?.ShowFlavourText(GetRandomResponse(successResponses) ?? $"Picked up {item.DisplayName}");
         onPickedUp?.Invoke();

--- a/Assets/Scripts/PersistentSingleton.cs
+++ b/Assets/Scripts/PersistentSingleton.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+/// <summary>
+/// Generic singleton base that persists across scene loads.
+/// </summary>
+public abstract class PersistentSingleton<T> : MonoBehaviour where T : MonoBehaviour
+{
+    /// <summary>
+    /// The single instance of this component.
+    /// </summary>
+    public static T Instance { get; private set; }
+
+    /// <summary>
+    /// Ensures only one instance exists and persists across scenes.
+    /// </summary>
+    protected virtual void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this as T;
+        DontDestroyOnLoad(gameObject);
+    }
+}

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -11,10 +11,6 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private float walkSpeed = 3f;
     [SerializeField] private float tiptoeSpeed = 1.5f;
 
-    [Header("References")]
-    [SerializeField] private InventorySystem inventory;
-    [SerializeField] private UIManager ui;
-
     private Rigidbody2D rb;
     private Vector2 input;
     private Vector2 facing = Vector2.down;
@@ -71,21 +67,21 @@ public class PlayerController : MonoBehaviour
         if (nearbyPickups.Count > 0)
         {
             var pickup = nearbyPickups[0];
-            pickup.Interact(inventory, ui);
+            pickup.Interact();
             return;
         }
 
         if (nearbyDoors.Count > 0)
         {
             var door = nearbyDoors[0];
-            door.Interact(inventory, ui);
+            door.Interact();
             return;
         }
 
         if (nearbyGhosts.Count > 0)
         {
             var ghost = nearbyGhosts[0];
-            ghost.Interact(inventory, ui);
+            ghost.Interact();
         }
     }
 

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -2,19 +2,25 @@ using UnityEngine;
 /// <summary>
 /// Displays inventory, flavour text, and interaction prompts.
 /// </summary>
-public class UIManager : MonoBehaviour
+public class UIManager : PersistentSingleton<UIManager>
 {
     [SerializeField] private Transform inventoryContainer;
     [SerializeField] private InventoryButton inventoryButtonPrefab;
     [SerializeField] private TypewriterText flavourText;
     [SerializeField] private TypewriterText prompt;
-    [SerializeField] private InventorySystem inventory;
+    private InventorySystem inventory;
 
-    private void Awake()
+    protected override void Awake()
     {
+        base.Awake();
+        if (Instance != this)
+        {
+            return;
+        }
+
         if (inventory == null)
         {
-            inventory = FindObjectOfType<InventorySystem>();
+            inventory = InventorySystem.Instance ?? FindObjectOfType<InventorySystem>();
         }
         if (inventory != null)
         {
@@ -30,7 +36,7 @@ public class UIManager : MonoBehaviour
 
     private void OnDestroy()
     {
-        if (inventory != null)
+        if (Instance == this && inventory != null)
         {
             inventory.ItemAdded -= OnInventoryChanged;
             inventory.ItemRemoved -= OnInventoryChanged;
@@ -68,7 +74,7 @@ public class UIManager : MonoBehaviour
             var button = Instantiate(inventoryButtonPrefab, inventoryContainer);
             var rt = button.GetComponent<RectTransform>();
             rt.anchoredPosition = new Vector2((index % 4) * 70, -(index / 4) * 70);
-            button.Initialize(item, this);
+            button.Initialize(item);
             index++;
         }
     }

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ All scripts are located in `Assets/Scripts/`. Attach them to appropriate GameObj
 ### PlayerController.cs
 Handles player movement, tiptoeing, and interaction input.
 - Attach to the player GameObject with a `Rigidbody2D`.
-- Assign references for `InventorySystem` and `UIManager`.
-- Uses a raycast in the facing direction to pick up `ItemPickup` objects and satisfy `GhostAI` using items from the inventory.
+- Uses global `InventorySystem` and `UIManager` singletons to pick up `ItemPickup` objects and satisfy `GhostAI` requirements.
 
 ### InventorySystem.cs
 Stores collected items and provides methods for checking and using them.


### PR DESCRIPTION
## Summary
- Refactor player and interactable scripts to fetch `InventorySystem` and `UIManager` via their singleton `Instance`
- Update UI components to rely on singleton access and streamline inventory button setup
- Clarify documentation to remove manual reference wiring and note persistent singletons

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6c459e6c832faa76513ddd3a4b8f