### PR TITLE
Track destroyed interactables

### DIFF
--- a/Assets/Scripts/DestroyState.cs
+++ b/Assets/Scripts/DestroyState.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+/// <summary>
+/// Tracks whether interactable objects have been destroyed.
+/// Uses PlayerPrefs for simple persistence across sessions.
+/// </summary>
+public static class DestroyState
+{
+    private static string GetKey(string id) => $"Destroyed_{id}";
+
+    /// <summary>
+    /// Returns true if the interactable with the given id was previously destroyed.
+    /// </summary>
+    public static bool IsDestroyed(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return false;
+        return PlayerPrefs.GetInt(GetKey(id), 0) == 1;
+    }
+
+    /// <summary>
+    /// Marks the interactable with the given id as destroyed.
+    /// </summary>
+    public static void MarkDestroyed(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return;
+        PlayerPrefs.SetInt(GetKey(id), 1);
+        PlayerPrefs.Save();
+    }
+}

--- a/Assets/Scripts/GhostAI.cs
+++ b/Assets/Scripts/GhostAI.cs
@@ -6,6 +6,7 @@ using UnityEngine.Events;
 /// </summary>
 public class GhostAI : MonoBehaviour
 {
+    [SerializeField] private string id;
     [SerializeField] private string[] requiredItemIds;
     [SerializeField] private bool consumeItem = true;
     [SerializeField] private bool isDefeated;
@@ -18,6 +19,15 @@ public class GhostAI : MonoBehaviour
     /// Item ids required to clear the ghost.
     /// </summary>
     public string[] RequiredItemIds => requiredItemIds;
+
+    private void Awake()
+    {
+        if (DestroyState.IsDestroyed(GetId()))
+        {
+            isDefeated = true;
+            gameObject.SetActive(false);
+        }
+    }
 
     /// <summary>
     /// Attempts to interact with the ghost using the player's inventory.
@@ -47,8 +57,8 @@ public class GhostAI : MonoBehaviour
                 ui?.RefreshInventory(inventory);
             }
         }
-
         isDefeated = true;
+        DestroyState.MarkDestroyed(GetId());
         onDefeated?.Invoke();
         var success = GetRandomResponse(successResponses);
         if (!string.IsNullOrEmpty(success))
@@ -57,6 +67,11 @@ public class GhostAI : MonoBehaviour
         }
         gameObject.SetActive(false);
         return true;
+    }
+
+    private string GetId()
+    {
+        return string.IsNullOrEmpty(id) ? gameObject.name : id;
     }
 
     private string GetRandomResponse(string[] responses)

--- a/Assets/Scripts/ItemPickup.cs
+++ b/Assets/Scripts/ItemPickup.cs
@@ -7,6 +7,7 @@ using UnityEngine.Events;
 public class ItemPickup : MonoBehaviour
 {
     [SerializeField] private Item item;
+    [SerializeField] private string id;
     [SerializeField] private string[] requiredItemIds;
     [SerializeField] private bool consumeItem;
     [SerializeField] private UnityEvent onPickedUp;
@@ -18,6 +19,15 @@ public class ItemPickup : MonoBehaviour
     /// The item granted when picked up.
     /// </summary>
     public Item Item => item;
+
+    private void Awake()
+    {
+        var key = GetId();
+        if (DestroyState.IsDestroyed(key))
+        {
+            Destroy(gameObject);
+        }
+    }
 
     /// <summary>
     /// Attempts to pick up the item using the player's inventory.
@@ -51,6 +61,7 @@ public class ItemPickup : MonoBehaviour
         ui?.RefreshInventory(inventory);
         ui?.ShowFlavourText(GetRandomResponse(successResponses) ?? $"Picked up {item.DisplayName}");
         onPickedUp?.Invoke();
+        DestroyState.MarkDestroyed(GetId());
         Destroy(gameObject);
         return true;
     }
@@ -59,5 +70,10 @@ public class ItemPickup : MonoBehaviour
     {
         if (responses == null || responses.Length == 0) return null;
         return responses[Random.Range(0, responses.Length)];
+    }
+
+    private string GetId()
+    {
+        return string.IsNullOrEmpty(id) ? item?.Id : id;
     }
 }


### PR DESCRIPTION
## Summary
- add DestroyState helper to persist destruction flags
- ensure ItemPickup objects delete themselves if previously collected
- make GhostAI remember when it has been defeated

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa742c33fc832fa51231fd48919884