### PR TITLE
Add menu, save/load, and audio settings systems

### DIFF
--- a/Assets/Scripts/InventorySystem.cs
+++ b/Assets/Scripts/InventorySystem.cs
@@ -119,6 +119,40 @@ public class InventorySystem : PersistentSingleton<InventorySystem>
         return Items;
     }
 
+    /// <summary>
+    /// Returns the ids of all items currently in the inventory.
+    /// Used by the save system.
+    /// </summary>
+    public List<string> GetItemIds()
+    {
+        List<string> ids = new List<string>();
+        foreach (Item item in Items)
+        {
+            ids.Add(item.Id);
+        }
+        return ids;
+    }
+
+    /// <summary>
+    /// Replaces the inventory contents with the given item ids.
+    /// </summary>
+    public void SetItemsByIds(IEnumerable<string> ids)
+    {
+        Items.Clear();
+        if (ids == null) return;
+        foreach (var id in ids)
+        {
+            if (string.IsNullOrEmpty(id)) continue;
+            var item = FindItem(id);
+            if (item != null)
+            {
+                Items.Add(item);
+                ItemAdded?.Invoke(item);
+            }
+        }
+        SaveInventory();
+    }
+
     private void LoadInventory()
     {
         Items.Clear();

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+/// <summary>
+/// Handles top level menu actions such as starting a new game,
+/// loading a save and quitting the application.
+/// Hook these methods up to UI buttons.
+/// </summary>
+public class MainMenu : MonoBehaviour
+{
+    [SerializeField] private string firstSceneName = "Bedroom";
+
+    /// <summary>
+    /// Starts a fresh game by clearing the save file
+    /// and loading the first gameplay scene.
+    /// </summary>
+    public void StartNewGame()
+    {
+        SaveLoadManager.Instance.Delete();
+        InventorySystem.Instance.SetItemsByIds(null);
+        RoomManager.Instance.LoadRoom(firstSceneName);
+    }
+
+    /// <summary>
+    /// Continues from the existing save if present.
+    /// </summary>
+    public void ContinueGame()
+    {
+        if (SaveLoadManager.Instance.SaveExists())
+        {
+            SaveLoadManager.Instance.Load();
+        }
+    }
+
+    /// <summary>
+    /// Exits the application.
+    /// </summary>
+    public void QuitGame()
+    {
+        Application.Quit();
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#endif
+    }
+}

--- a/Assets/Scripts/PauseMenu.cs
+++ b/Assets/Scripts/PauseMenu.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Toggles game pausing and exposes UI events for saving,
+/// loading or returning to the main menu.
+/// </summary>
+public class PauseMenu : MonoBehaviour
+{
+    [SerializeField] private GameObject menuRoot;
+    [SerializeField] private string mainMenuScene = "MainMenu";
+    private bool isPaused;
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Escape))
+        {
+            if (isPaused) Resume(); else Pause();
+        }
+    }
+
+    public void Pause()
+    {
+        Time.timeScale = 0f;
+        if (menuRoot != null) menuRoot.SetActive(true);
+        isPaused = true;
+    }
+
+    public void Resume()
+    {
+        Time.timeScale = 1f;
+        if (menuRoot != null) menuRoot.SetActive(false);
+        isPaused = false;
+    }
+
+    public void SaveGame()
+    {
+        SaveLoadManager.Instance.Save();
+    }
+
+    public void LoadGame()
+    {
+        SaveLoadManager.Instance.Load();
+        Resume();
+    }
+
+    public void QuitToMenu()
+    {
+        Time.timeScale = 1f;
+        SceneManager.LoadScene(mainMenuScene);
+    }
+}

--- a/Assets/Scripts/RoomManager.cs
+++ b/Assets/Scripts/RoomManager.cs
@@ -6,6 +6,8 @@ using UnityEngine.SceneManagement;
 /// </summary>
 public class RoomManager : PersistentSingleton<RoomManager>
 {
+    public string CurrentRoom { get; private set; }
+
     protected override void Awake()
     {
         base.Awake();
@@ -13,17 +15,19 @@ public class RoomManager : PersistentSingleton<RoomManager>
         {
             return;
         }
+        CurrentRoom = SceneManager.GetActiveScene().name;
     }
 
 
     [SerializeField] private SoundManager soundManager;
     /// <summary>
-    /// Loads a room scene by name.
+    /// Loads a room scene by name and records it as the current room.
     /// </summary>
     public void LoadRoom(string sceneName)
     {
+        CurrentRoom = sceneName;
         SceneManager.LoadScene(sceneName);
     }
 
-    
+
 }

--- a/Assets/Scripts/SaveLoadManager.cs
+++ b/Assets/Scripts/SaveLoadManager.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// Handles serialising and deserialising persistent game data.
+/// Uses a single JSON save file under
+/// <see cref="Application.persistentDataPath"/>.
+/// </summary>
+public class SaveLoadManager : PersistentSingleton<SaveLoadManager>
+{
+    private const string FileName = "save.json";
+
+    /// <summary>
+    /// Data representation of the player's progress.
+    /// </summary>
+    [System.Serializable]
+    public class SaveData
+    {
+        public string roomName;
+        public float[] playerPosition;
+        public List<string> inventoryIds;
+    }
+
+    /// <summary>
+    /// Saves the current game state to disk.
+    /// </summary>
+    public void Save()
+    {
+        var data = new SaveData();
+        data.roomName = RoomManager.Instance.CurrentRoom;
+
+        var player = GameObject.FindWithTag("Player");
+        if (player != null)
+        {
+            Vector3 pos = player.transform.position;
+            data.playerPosition = new float[3] { pos.x, pos.y, pos.z };
+        }
+        data.inventoryIds = InventorySystem.Instance.GetItemIds();
+
+        string json = JsonUtility.ToJson(data, true);
+        File.WriteAllText(GetPath(), json);
+    }
+
+    /// <summary>
+    /// Loads the game state from disk.
+    /// </summary>
+    public void Load()
+    {
+        string path = GetPath();
+        if (!File.Exists(path)) return;
+        string json = File.ReadAllText(path);
+        var data = JsonUtility.FromJson<SaveData>(json);
+        StartCoroutine(LoadRoutine(data));
+    }
+
+    private IEnumerator LoadRoutine(SaveData data)
+    {
+        RoomManager.Instance.LoadRoom(data.roomName);
+        yield return null;
+
+        var player = GameObject.FindWithTag("Player");
+        if (player != null && data.playerPosition != null && data.playerPosition.Length == 3)
+        {
+            player.transform.position = new Vector3(data.playerPosition[0], data.playerPosition[1], data.playerPosition[2]);
+        }
+
+        InventorySystem.Instance.SetItemsByIds(data.inventoryIds);
+    }
+
+    /// <summary>
+    /// Deletes the save file.
+    /// </summary>
+    public void Delete()
+    {
+        string path = GetPath();
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Returns whether a save file exists.
+    /// </summary>
+    public bool SaveExists()
+    {
+        return File.Exists(GetPath());
+    }
+
+    private string GetPath()
+    {
+        return Path.Combine(Application.persistentDataPath, FileName);
+    }
+}

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+/// <summary>
+/// Stores and applies player configurable settings such as audio volume.
+/// Values are persisted via <see cref="PlayerPrefs"/>.
+/// </summary>
+public class SettingsManager : PersistentSingleton<SettingsManager>
+{
+    private const string MusicVolKey = "MusicVolume";
+    private const string SfxVolKey = "SfxVolume";
+
+    public float MusicVolume { get; private set; } = 1f;
+    public float SfxVolume { get; private set; } = 1f;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        Load();
+        Apply();
+    }
+
+    private void Load()
+    {
+        MusicVolume = PlayerPrefs.GetFloat(MusicVolKey, 1f);
+        SfxVolume = PlayerPrefs.GetFloat(SfxVolKey, 1f);
+    }
+
+    private void Apply()
+    {
+        SoundManager.Instance.SetMusicVolume(MusicVolume);
+        SoundManager.Instance.SetSFXVolume(SfxVolume);
+    }
+
+    public void SetMusicVolume(float value)
+    {
+        MusicVolume = Mathf.Clamp01(value);
+        SoundManager.Instance.SetMusicVolume(MusicVolume);
+        PlayerPrefs.SetFloat(MusicVolKey, MusicVolume);
+        PlayerPrefs.Save();
+    }
+
+    public void SetSfxVolume(float value)
+    {
+        SfxVolume = Mathf.Clamp01(value);
+        SoundManager.Instance.SetSFXVolume(SfxVolume);
+        PlayerPrefs.SetFloat(SfxVolKey, SfxVolume);
+        PlayerPrefs.Save();
+    }
+}

--- a/Assets/Scripts/SettingsMenu.cs
+++ b/Assets/Scripts/SettingsMenu.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Bridges UI controls to the <see cref="SettingsManager"/>.
+/// Intended to be placed on an options menu panel.
+/// </summary>
+public class SettingsMenu : MonoBehaviour
+{
+    [SerializeField] private Slider musicSlider;
+    [SerializeField] private Slider sfxSlider;
+
+    private void Start()
+    {
+        if (musicSlider != null)
+            musicSlider.value = SettingsManager.Instance.MusicVolume;
+        if (sfxSlider != null)
+            sfxSlider.value = SettingsManager.Instance.SfxVolume;
+    }
+
+    public void OnMusicVolumeChanged(float value)
+    {
+        SettingsManager.Instance.SetMusicVolume(value);
+    }
+
+    public void OnSfxVolumeChanged(float value)
+    {
+        SettingsManager.Instance.SetSfxVolume(value);
+    }
+}

--- a/Assets/Scripts/SoundManager.cs
+++ b/Assets/Scripts/SoundManager.cs
@@ -16,6 +16,14 @@ public class SoundManager : PersistentSingleton<SoundManager>
 
     [SerializeField] private AudioSource musicSource;
     [SerializeField] private AudioSource sfxSource;
+    [SerializeField, Range(0f,1f)] private float musicVolume = 1f;
+    [SerializeField, Range(0f,1f)] private float sfxVolume = 1f;
+
+    private void Start()
+    {
+        SetMusicVolume(musicVolume);
+        SetSFXVolume(sfxVolume);
+    }
 
     /// <summary>
     /// Plays a looping background track.
@@ -45,4 +53,27 @@ public class SoundManager : PersistentSingleton<SoundManager>
         if (sfxSource == null || clip == null) return;
         sfxSource.PlayOneShot(clip);
     }
+
+    /// <summary>
+    /// Sets the music channel volume (0-1).
+    /// </summary>
+    public void SetMusicVolume(float volume)
+    {
+        musicVolume = Mathf.Clamp01(volume);
+        if (musicSource != null)
+            musicSource.volume = musicVolume;
+    }
+
+    /// <summary>
+    /// Sets the sound effect channel volume (0-1).
+    /// </summary>
+    public void SetSFXVolume(float volume)
+    {
+        sfxVolume = Mathf.Clamp01(volume);
+        if (sfxSource != null)
+            sfxSource.volume = sfxVolume;
+    }
+
+    public float GetMusicVolume() => musicVolume;
+    public float GetSFXVolume() => sfxVolume;
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UnityProject-Short
 
-This repository contains a minimal Unity project with foundational scripts for a 1-bit style adventure prototype. These scripts provide basic gameplay behaviour for movement, inventory management, and more.
+This repository contains a minimal Unity project with foundational scripts for a 1-bit style adventure prototype. These scripts provide basic gameplay behaviour for movement, inventory management, and more. Utility components also supply menu navigation, save/load functionality, and configurable audio settings.
 
 ## Scripts
 All scripts are located in `Assets/Scripts/`. Attach them to appropriate GameObjects in your scenes and configure their fields in the Unity Inspector.
@@ -29,14 +29,35 @@ Manages ghost behavior that blocks progress until a specific item is used.
 - UnityEvents `onDefeated` and `onFailed` fire on success or failure.
 
 ### RoomManager.cs
-Loads room scenes and applies atmosphere cues.
-- Define `RoomSettings` to pair room ids with ambient clips and lighting.
-- Use `LoadRoom` to transition to another scene and call `ApplyAtmosphere` after loading.
+Tracks and loads room scenes.
+- `LoadRoom` transitions to the target scene and records it as the current room.
 
 ### SoundManager.cs
 Plays background music and sound effects.
 - Requires two `AudioSource` components: one for music and one for SFX.
-- Provides `StopMusic` to halt the current track.
+- Provides `StopMusic` to halt the current track and exposes `SetMusicVolume` and `SetSFXVolume` for runtime volume control.
+
+### SaveLoadManager.cs
+Persists player progress to a single JSON save file.
+- Call `Save()` and `Load()` to write or read data.
+- Stores the current room, player position, and inventory item ids.
+
+### MainMenu.cs
+Button callbacks for the title screen.
+- `StartNewGame()` clears an existing save and loads the first scene.
+- `ContinueGame()` loads the save file if present.
+- `QuitGame()` exits the application.
+
+### PauseMenu.cs
+Toggles gameplay pausing and exposes additional menu actions.
+- Pressing *Escape* calls `Pause()`/`Resume()`.
+- `SaveGame()` and `LoadGame()` bridge to `SaveLoadManager`.
+- `QuitToMenu()` returns to the main menu scene.
+
+### SettingsManager.cs & SettingsMenu.cs
+Maintain and display user configurable options.
+- Currently supports music and SFX volume with values stored in `PlayerPrefs`.
+- `SettingsMenu` links UI sliders to the manager.
 
 ### UIManager.cs
 Displays inventory contents, flavour text, and interaction prompts.
@@ -66,6 +87,7 @@ Prefab templates for these systems are provided in `Assets/Prefabs/`. Drop them 
 2. Populate scenes with interactable objects and ghosts, assigning the appropriate scripts.
 3. Create `Item` assets for Lamp, Spatula, Shoes, Insecticide, Stool, Toilet Brush, Garden Key, Jacket, Cough Medicine, Bucket, and Shovel.
 4. Run **Tools > Build Prefabs** to generate prefabs for the core systems.
+5. Set up UI canvases using `MainMenu`, `PauseMenu`, and `SettingsMenu` to enable saving/loading and audio options.
 
 These scripts form a basic framework for the prototype—extend them further to complete the game.
 


### PR DESCRIPTION
## Summary
- Implement SaveLoadManager for JSON saves
- Add main and pause menu scripts for navigation and pausing
- Provide persistent audio settings with SettingsManager
- Update SoundManager and InventorySystem to support saves and volume control
- Refresh README with menu, save/load, and settings docs

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab08965d78832fa2db5380aeeb5fb9