### PR TITLE
feat: enhance door transitions and item audio

### DIFF
--- a/Assets/Scripts/DestroyState.cs
+++ b/Assets/Scripts/DestroyState.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 public static class DestroyState
 {
     private static string GetKey(string id) => $"Destroyed_{id}";
+    private const string AllKey = "Destroyed_All";
 
     /// <summary>
     /// Returns true if the interactable with the given id was previously destroyed.
@@ -24,6 +25,27 @@ public static class DestroyState
     {
         if (string.IsNullOrEmpty(id)) return;
         PlayerPrefs.SetInt(GetKey(id), 1);
+        var list = PlayerPrefs.GetString(AllKey, string.Empty);
+        if (!list.Contains($",{id},"))
+        {
+            list = $",{id}," + list;
+            PlayerPrefs.SetString(AllKey, list);
+        }
+        PlayerPrefs.Save();
+    }
+
+    public static void ResetAll()
+    {
+        var list = PlayerPrefs.GetString(AllKey, string.Empty);
+        if (!string.IsNullOrEmpty(list))
+        {
+            var ids = list.Split(',', System.StringSplitOptions.RemoveEmptyEntries);
+            foreach (var id in ids)
+            {
+                PlayerPrefs.DeleteKey(GetKey(id));
+            }
+        }
+        PlayerPrefs.DeleteKey(AllKey);
         PlayerPrefs.Save();
     }
 }

--- a/Assets/Scripts/Door.cs
+++ b/Assets/Scripts/Door.cs
@@ -7,6 +7,7 @@ using UnityEngine.Events;
 public class Door : MonoBehaviour
 {
     [SerializeField] private string targetScene;
+    [SerializeField] private string targetSpawnId;
     [SerializeField] private string[] requiredItemIds;
     [SerializeField] private bool consumeItem;
     [SerializeField] private UnityEvent onOpened;
@@ -59,7 +60,7 @@ public class Door : MonoBehaviour
 
         if (roomManager != null && !string.IsNullOrEmpty(targetScene))
         {
-            roomManager.LoadRoom(targetScene);
+            roomManager.LoadRoom(targetScene, targetSpawnId);
         }
         return true;
     }

--- a/Assets/Scripts/InventoryButton.cs
+++ b/Assets/Scripts/InventoryButton.cs
@@ -42,6 +42,7 @@ public class InventoryButton : MonoBehaviour
         if (item != null)
         {
             UIManager.Instance?.ShowFlavourText(item.Description);
+            SoundManager.Instance?.PlaySFX(item.Sound);
         }
     }
 }

--- a/Assets/Scripts/InventorySystem.cs
+++ b/Assets/Scripts/InventorySystem.cs
@@ -108,6 +108,7 @@ public class InventorySystem : PersistentSingleton<InventorySystem>
         Items.Remove(item);
         ItemRemoved?.Invoke(item);
         SaveInventory();
+        SoundManager.Instance?.PlaySFX(item.Sound);
         return item;
     }
 

--- a/Assets/Scripts/InventoryUI.cs
+++ b/Assets/Scripts/InventoryUI.cs
@@ -3,10 +3,12 @@ using UnityEngine;
 /// <summary>
 /// Toggles the inventory panel when the player presses a key.
 /// </summary>
-public class InventoryUI : PersistentSingleton<InventoryUI>
-{
-    [SerializeField] private GameObject inventoryPanel;
-    [SerializeField] private KeyCode toggleKey = KeyCode.I;
+    public class InventoryUI : PersistentSingleton<InventoryUI>
+    {
+        [SerializeField] private GameObject inventoryPanel;
+        [SerializeField] private KeyCode toggleKey = KeyCode.I;
+
+        public bool IsInventoryOpen => inventoryPanel != null && inventoryPanel.activeSelf;
 
     protected override void Awake()
     {

--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -10,8 +10,10 @@ public class Item : ScriptableObject
     [SerializeField] private string displayName;
     [TextArea] [SerializeField] private string description;
     [SerializeField] private Sprite sprite;
+    [SerializeField] private AudioClip sound;
     public Sprite Sprite => sprite;
     public string Id => id;
     public string DisplayName => displayName;
     public string Description => description;
+    public AudioClip Sound => sound;
 }

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -26,6 +26,7 @@ public class MainMenu : MonoBehaviour
     {
         SaveLoadManager.Instance.Delete();
         InventorySystem.Instance.SetItemsByIds(null);
+        DestroyState.ResetAll();
         RoomManager.Instance.LoadRoom(firstSceneName);
     }
 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -43,6 +43,13 @@ public class PlayerController : MonoBehaviour
 
     private void HandleInput()
     {
+        if (InventoryUI.Instance != null && InventoryUI.Instance.IsInventoryOpen)
+        {
+            input = Vector2.zero;
+            rb.velocity = Vector2.zero;
+            return;
+        }
+
         input = Vector2.zero;
         if (Input.GetKey(KeyCode.W)) input.y += 1f;
         if (Input.GetKey(KeyCode.S)) input.y -= 1f;

--- a/Assets/Scripts/RoomManager.cs
+++ b/Assets/Scripts/RoomManager.cs
@@ -8,6 +8,8 @@ public class RoomManager : PersistentSingleton<RoomManager>
 {
     public string CurrentRoom { get; private set; }
 
+    private string pendingSpawnId;
+
     protected override void Awake()
     {
         base.Awake();
@@ -22,12 +24,31 @@ public class RoomManager : PersistentSingleton<RoomManager>
     [SerializeField] private SoundManager soundManager;
     /// <summary>
     /// Loads a room scene by name and records it as the current room.
+    /// Optionally moves the player to a spawn point in the new scene.
     /// </summary>
-    public void LoadRoom(string sceneName)
+    public void LoadRoom(string sceneName, string spawnPointId = null)
     {
         CurrentRoom = sceneName;
+        pendingSpawnId = spawnPointId;
+        SceneManager.sceneLoaded += OnSceneLoaded;
         SceneManager.LoadScene(sceneName);
     }
 
-
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (!string.IsNullOrEmpty(pendingSpawnId))
+        {
+            var spawn = GameObject.Find(pendingSpawnId);
+            if (spawn != null)
+            {
+                var player = GameObject.FindWithTag("Player");
+                if (player != null)
+                {
+                    player.transform.position = spawn.transform.position;
+                }
+            }
+            pendingSpawnId = null;
+        }
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
 }


### PR DESCRIPTION
## Summary
- allow doors to specify a spawn point in the destination scene
- play item-specific sounds when inventory items are clicked or consumed
- block player movement while the inventory UI is open
- reset destroyed item/ghost states when starting a new game

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ab313e40ac832f8719be4c0e7eab61