### PR TITLE
Add pixel art sprite shader effects with outlines

### DIFF
--- a/Assets/Scenes/Bathroom Test Timo.unity
+++ b/Assets/Scenes/Bathroom Test Timo.unity
@@ -700,7 +700,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f1b37b6ac278ac04195a1a14658b3cf8, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -746,6 +746,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1998182543}
+  - {fileID: 1558414323}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &824622977
@@ -849,7 +850,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   highlightColor: {r: 0.03773582, g: 0.037267774, b: 0.03186185, a: 1}
   outlineSize: 1
-  outlineShader: {fileID: 0}
+  outlineShader: {fileID: 4800000, guid: 1b59dfc599eb47a881f5368693ea8d5e, type: 3}
 --- !u!82 &824622980
 AudioSource:
   m_ObjectHideFlags: 0
@@ -1353,6 +1354,112 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3bd4f7e0e309b92499d1190de514186a, type: 3}
+--- !u!1 &1558414322
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1558414323}
+  - component: {fileID: 1558414325}
+  - component: {fileID: 1558414324}
+  m_Layer: 0
+  m_Name: bathroom_enemy_reflection (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1558414323
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558414322}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.13100004, y: 0.254, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 824622976}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &1558414324
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558414322}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: d08e797df6620834a930a84b2adc49d4, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!212 &1558414325
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558414322}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d679be60a0bd60f48a1a6e881053dcea, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 574388582, guid: 79d8cb8328f935a469f46975c95c26c4, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.3882353}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4, y: 4}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &1585233515
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1766,7 +1873,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  - {fileID: 2100000, guid: f1b37b6ac278ac04195a1a14658b3cf8, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Scenes/Livingroom.unity
+++ b/Assets/Scenes/Livingroom.unity
@@ -1065,7 +1065,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   highlightColor: {r: 0, g: 0, b: 0, a: 1}
   outlineSize: 1
-  outlineShader: {fileID: 0}
+  outlineShader: {fileID: 4800000, guid: 1b59dfc599eb47a881f5368693ea8d5e, type: 3}
 --- !u!61 &1058165197
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Livingroom.unity
+++ b/Assets/Scenes/Livingroom.unity
@@ -450,6 +450,268 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+--- !u!1 &596935474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 596935475}
+  - component: {fileID: 596935476}
+  m_Layer: 0
+  m_Name: Livingroom (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &596935475
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596935474}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3.5, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1058165201}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &596935476
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596935474}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d679be60a0bd60f48a1a6e881053dcea, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 1e0ac5037dc07f6479006768a68620f9, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 14, y: 8}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1001 &913013571
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1058165201}
+    m_Modifications:
+    - target: {fileID: 218661866984916667, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: highlightColor.b
+      value: 0.39215687
+      objectReference: {fileID: 0}
+    - target: {fileID: 218661866984916667, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: highlightColor.g
+      value: 0.39215687
+      objectReference: {fileID: 0}
+    - target: {fileID: 218661866984916667, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: highlightColor.r
+      value: 0.39215687
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Size.y
+      value: 2.8534355
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Offset.y
+      value: -0.92671776
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.border.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.border.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.border.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.border.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.newSize.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.newSize.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.oldSize.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.oldSize.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086841983082199787, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Name
+      value: Garden Key (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -658061052, guid: 6ceed08971aaccc4aa8a891e8b130520, type: 3}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: d679be60a0bd60f48a1a6e881053dcea, type: 2}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: id
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: item
+      value: 
+      objectReference: {fileID: 11400000, guid: f0a800503719fd6478276e06b06a56f1, type: 2}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: consumeItem
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: failedResponses.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: requiredItemIds.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: successResponses.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: failedResponses.Array.data[0]
+      value: I can't reach it.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: failedResponses.Array.data[1]
+      value: If my arm was longer, I could knock it off.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: failedResponses.Array.data[2]
+      value: The spatula is too short to reach it.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: requiredItemIds.Array.data[0]
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: successResponses.Array.data[0]
+      value: The key for the garden door.
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+--- !u!4 &913013572 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+  m_PrefabInstance: {fileID: 913013571}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1019584306
 GameObject:
   m_ObjectHideFlags: 0
@@ -507,7 +769,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: -1
   m_Sprite: {fileID: 21300000, guid: 1e0ac5037dc07f6479006768a68620f9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -931,7 +1193,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  - {fileID: 2100000, guid: d679be60a0bd60f48a1a6e881053dcea, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -975,7 +1237,10 @@ Transform:
   m_LocalPosition: {x: -3.5, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 596935475}
+  - {fileID: 1120700724}
+  - {fileID: 913013572}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1112420127
@@ -1149,6 +1414,124 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1120700723
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1058165201}
+    m_Modifications:
+    - target: {fileID: 218661866984916667, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: highlightColor.b
+      value: 0.39215687
+      objectReference: {fileID: 0}
+    - target: {fileID: 218661866984916667, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: highlightColor.g
+      value: 0.39215687
+      objectReference: {fileID: 0}
+    - target: {fileID: 218661866984916667, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: highlightColor.r
+      value: 0.39215687
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.newSize.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 356119847346795356, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SpriteTilingProperty.newSize.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086841983082199787, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Name
+      value: Shoes (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -682074173, guid: 6ceed08971aaccc4aa8a891e8b130520, type: 3}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289074834795746837, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: d679be60a0bd60f48a1a6e881053dcea, type: 2}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: item
+      value: 
+      objectReference: {fileID: 11400000, guid: b1a031916d69f1c43acc3e7a28d05184, type: 2}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: failedResponses.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: successResponses.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083909586666423228, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+      propertyPath: successResponses.Array.data[0]
+      value: I can use these to go outside.
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+--- !u!4 &1120700724 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1346474321720459833, guid: ffa4aaa4dbb980147a52f5f6d36c32dd, type: 3}
+  m_PrefabInstance: {fileID: 1120700723}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1191485424
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ItemPickup.cs
+++ b/Assets/Scripts/ItemPickup.cs
@@ -61,7 +61,8 @@ public class ItemPickup : MonoBehaviour
         ui?.RefreshInventory(inventory);
         ui?.ShowFlavourText(GetRandomResponse(successResponses) ?? $"Picked up {item.DisplayName}");
         onPickedUp?.Invoke();
-        SoundManager.Instance.PlaySFX(item.Sound);
+        
+        SoundManager.Instance?.PlaySFX(item.Sound);
         DestroyState.MarkDestroyed(GetId());
         Destroy(gameObject);
         return true;

--- a/Assets/Scripts/ProximityHighlight.cs
+++ b/Assets/Scripts/ProximityHighlight.cs
@@ -34,6 +34,7 @@ public class ProximityHighlight : MonoBehaviour, IHighlightable
         if (outlineShader != null)
         {
             outlineMaterial = new Material(outlineShader);
+            outlineMaterial.CopyPropertiesFromMaterial(originalMaterial);
         }
         else
         {
@@ -52,9 +53,12 @@ public class ProximityHighlight : MonoBehaviour, IHighlightable
 
         if (highlighted && outlineMaterial != null)
         {
+            //outlineMaterial.CopyPropertiesFromMaterial(originalMaterial);
             outlineMaterial.SetColor("_OutlineColor", highlightColor);
             outlineMaterial.SetFloat("_OutlineSize", outlineSize);
+            
             spriteRenderer.material = outlineMaterial;
+           
         }
         else
         {

--- a/Assets/Shaders/Outline.shader
+++ b/Assets/Shaders/Outline.shader
@@ -3,6 +3,7 @@ Shader "Custom/Outline"
     Properties
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
         _OutlineColor ("Outline Color", Color) = (1,1,0,1)
         _OutlineSize ("Outline Size", Float) = 1
     }
@@ -25,16 +26,19 @@ Shader "Custom/Outline"
             {
                 float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             struct v2f
             {
                 float4 vertex : SV_POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             sampler2D _MainTex;
             float4 _MainTex_TexelSize;
+            fixed4 _Color;
             fixed4 _OutlineColor;
             float _OutlineSize;
 
@@ -43,12 +47,13 @@ Shader "Custom/Outline"
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
+                o.color = v.color * _Color;
                 return o;
             }
 
             fixed4 frag (v2f i) : SV_Target
             {
-                fixed4 c = tex2D(_MainTex, i.uv);
+                fixed4 c = tex2D(_MainTex, i.uv) * i.color;
                 if (c.a == 0)
                 {
                     float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
@@ -59,7 +64,7 @@ Shader "Custom/Outline"
                     alpha += tex2D(_MainTex, i.uv + float2(0, -offset.y)).a;
                     if (alpha > 0)
                     {
-                        return _OutlineColor;
+                        return _OutlineColor * i.color;
                     }
                     return 0;
                 }

--- a/Assets/Shaders/PixelArt.meta
+++ b/Assets/Shaders/PixelArt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 505e170d49424e0ca1ee99f660d345a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/PixelArt/SpriteMelt.mat
+++ b/Assets/Shaders/PixelArt/SpriteMelt.mat
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SpriteMelt
+  m_Shader: {fileID: 4800000, guid: 87adf215da944c258c9fea95440b5c3d, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Amount: 0.046
+    - _BlockSize: 1
+    - _EnableExternalAlpha: 0
+    - _Intensity: 0
+    - _Jitter: 0
+    - _Speed: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Shaders/PixelArt/SpriteMelt.mat.meta
+++ b/Assets/Shaders/PixelArt/SpriteMelt.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddf9fa0f11c49e14fa548b4f0aef5743
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/PixelArt/SpriteMelt.shader
+++ b/Assets/Shaders/PixelArt/SpriteMelt.shader
@@ -1,0 +1,64 @@
+Shader "Custom/PixelArt/Melt"
+{
+    Properties
+    {
+        _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Amount ("Melt Amount", Range(0,1)) = 1
+        _Speed ("Melt Speed", Float) = 1
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float _Amount;
+            float _Speed;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            float2 ApplyMelt(float2 uv)
+            {
+                float melt = frac(_Time.y * _Speed) * _Amount;
+                uv.y += melt * (1 - uv.y);
+                uv.x += sin(uv.y * 40 + _Time.y * 10) * 0.05 * melt;
+                return uv;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float2 uv = ApplyMelt(i.uv);
+                return tex2D(_MainTex, uv);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PixelArt/SpriteMelt.shader
+++ b/Assets/Shaders/PixelArt/SpriteMelt.shader
@@ -3,6 +3,7 @@ Shader "Custom/PixelArt/Melt"
     Properties
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
         _Amount ("Melt Amount", Range(0,1)) = 1
         _Speed ("Melt Speed", Float) = 1
     }
@@ -25,15 +26,18 @@ Shader "Custom/PixelArt/Melt"
             {
                 float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             struct v2f
             {
                 float4 vertex : SV_POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             sampler2D _MainTex;
+            fixed4 _Color;
             float _Amount;
             float _Speed;
 
@@ -42,6 +46,7 @@ Shader "Custom/PixelArt/Melt"
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
+                o.color = v.color * _Color;
                 return o;
             }
 
@@ -56,7 +61,7 @@ Shader "Custom/PixelArt/Melt"
             fixed4 frag (v2f i) : SV_Target
             {
                 float2 uv = ApplyMelt(i.uv);
-                return tex2D(_MainTex, uv);
+                return tex2D(_MainTex, uv) * i.color;
             }
             ENDCG
         }

--- a/Assets/Shaders/PixelArt/SpriteMelt.shader
+++ b/Assets/Shaders/PixelArt/SpriteMelt.shader
@@ -4,8 +4,10 @@ Shader "Custom/PixelArt/Melt"
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
         _Color ("Tint", Color) = (1,1,1,1)
-        _Amount ("Melt Amount", Range(0,1)) = 1
-        _Speed ("Melt Speed", Float) = 1
+        _Speed ("Melt Speed", Float) = 2
+        _BlockSize ("Block Size", Float) = 50
+        _Intensity ("Melt Intensity", Range(0,1)) = 1
+        _Jitter ("Horizontal Jitter", Range(0,1)) = 0.2
     }
     SubShader
     {
@@ -38,8 +40,10 @@ Shader "Custom/PixelArt/Melt"
 
             sampler2D _MainTex;
             fixed4 _Color;
-            float _Amount;
             float _Speed;
+            float _BlockSize;
+            float _Intensity;
+            float _Jitter;
 
             v2f vert (appdata v)
             {
@@ -50,11 +54,25 @@ Shader "Custom/PixelArt/Melt"
                 return o;
             }
 
+            float rand(float2 p)
+            {
+                float3 p3 = frac(float3(p.xyx) * 0.1031);
+                p3 += dot(p3, p3.yzx + 33.33);
+                return frac((p3.x + p3.y) * p3.z);
+            }
+
             float2 ApplyMelt(float2 uv)
             {
-                float melt = frac(_Time.y * _Speed) * _Amount;
-                uv.y += melt * (1 - uv.y);
-                uv.x += sin(uv.y * 40 + _Time.y * 10) * 0.05 * melt;
+                float t = _Time.y * _Speed;
+                float2 ruv = uv * _BlockSize;
+                float2 id = floor(ruv);
+                float rnd = rand(id.xx);
+                float2 offsetUv = ruv;
+                offsetUv.y += t * (rnd * 0.75 + 0.5) * _Intensity;
+                float2 guv = frac(offsetUv);
+                offsetUv = floor(offsetUv) + guv;
+                uv = offsetUv / _BlockSize;
+                uv.x += sin(uv.y * 10 + t) * _Jitter * _Intensity;
                 return uv;
             }
 

--- a/Assets/Shaders/PixelArt/SpriteMelt.shader.meta
+++ b/Assets/Shaders/PixelArt/SpriteMelt.shader.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 87adf215da944c258c9fea95440b5c3d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  validGlobalKeywords: []
+  invalidGlobalKeywords: []
+  validLocalKeywords: []
+  invalidLocalKeywords: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/PixelArt/SpriteMeltOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteMeltOutline.shader
@@ -1,0 +1,84 @@
+Shader "Custom/PixelArt/MeltOutline"
+{
+    Properties
+    {
+        _MainTex ("Sprite Texture", 2D) = "white" {}
+        _OutlineColor ("Outline Color", Color) = (1,1,0,1)
+        _OutlineSize ("Outline Size", Float) = 1
+        _Amount ("Melt Amount", Range(0,1)) = 1
+        _Speed ("Melt Speed", Float) = 1
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+            fixed4 _OutlineColor;
+            float _OutlineSize;
+            float _Amount;
+            float _Speed;
+
+            float2 ApplyMelt(float2 uv)
+            {
+                float melt = frac(_Time.y * _Speed) * _Amount;
+                uv.y += melt * (1 - uv.y);
+                uv.x += sin(uv.y * 40 + _Time.y * 10) * 0.05 * melt;
+                return uv;
+            }
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float2 uv = ApplyMelt(i.uv);
+                fixed4 c = tex2D(_MainTex, uv);
+                if (c.a == 0)
+                {
+                    float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
+                    float alpha = 0;
+                    alpha += tex2D(_MainTex, ApplyMelt(i.uv + float2(offset.x, 0))).a;
+                    alpha += tex2D(_MainTex, ApplyMelt(i.uv + float2(-offset.x, 0))).a;
+                    alpha += tex2D(_MainTex, ApplyMelt(i.uv + float2(0, offset.y))).a;
+                    alpha += tex2D(_MainTex, ApplyMelt(i.uv + float2(0, -offset.y))).a;
+                    if (alpha > 0)
+                    {
+                        return _OutlineColor;
+                    }
+                    return 0;
+                }
+                return c;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PixelArt/SpriteMeltOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteMeltOutline.shader
@@ -3,6 +3,7 @@ Shader "Custom/PixelArt/MeltOutline"
     Properties
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
         _OutlineColor ("Outline Color", Color) = (1,1,0,1)
         _OutlineSize ("Outline Size", Float) = 1
         _Amount ("Melt Amount", Range(0,1)) = 1
@@ -27,16 +28,19 @@ Shader "Custom/PixelArt/MeltOutline"
             {
                 float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             struct v2f
             {
                 float4 vertex : SV_POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             sampler2D _MainTex;
             float4 _MainTex_TexelSize;
+            fixed4 _Color;
             fixed4 _OutlineColor;
             float _OutlineSize;
             float _Amount;
@@ -55,13 +59,14 @@ Shader "Custom/PixelArt/MeltOutline"
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
+                o.color = v.color * _Color;
                 return o;
             }
 
             fixed4 frag (v2f i) : SV_Target
             {
                 float2 uv = ApplyMelt(i.uv);
-                fixed4 c = tex2D(_MainTex, uv);
+                fixed4 c = tex2D(_MainTex, uv) * i.color;
                 if (c.a == 0)
                 {
                     float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
@@ -72,7 +77,7 @@ Shader "Custom/PixelArt/MeltOutline"
                     alpha += tex2D(_MainTex, ApplyMelt(i.uv + float2(0, -offset.y))).a;
                     if (alpha > 0)
                     {
-                        return _OutlineColor;
+                        return _OutlineColor * i.color;
                     }
                     return 0;
                 }

--- a/Assets/Shaders/PixelArt/SpriteMeltOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteMeltOutline.shader
@@ -6,8 +6,10 @@ Shader "Custom/PixelArt/MeltOutline"
         _Color ("Tint", Color) = (1,1,1,1)
         _OutlineColor ("Outline Color", Color) = (1,1,0,1)
         _OutlineSize ("Outline Size", Float) = 1
-        _Amount ("Melt Amount", Range(0,1)) = 1
-        _Speed ("Melt Speed", Float) = 1
+        _Speed ("Melt Speed", Float) = 2
+        _BlockSize ("Block Size", Float) = 50
+        _Intensity ("Melt Intensity", Range(0,1)) = 1
+        _Jitter ("Horizontal Jitter", Range(0,1)) = 0.2
     }
     SubShader
     {
@@ -43,14 +45,30 @@ Shader "Custom/PixelArt/MeltOutline"
             fixed4 _Color;
             fixed4 _OutlineColor;
             float _OutlineSize;
-            float _Amount;
             float _Speed;
+            float _BlockSize;
+            float _Intensity;
+            float _Jitter;
+
+            float rand(float2 p)
+            {
+                float3 p3 = frac(float3(p.xyx) * 0.1031);
+                p3 += dot(p3, p3.yzx + 33.33);
+                return frac((p3.x + p3.y) * p3.z);
+            }
 
             float2 ApplyMelt(float2 uv)
             {
-                float melt = frac(_Time.y * _Speed) * _Amount;
-                uv.y += melt * (1 - uv.y);
-                uv.x += sin(uv.y * 40 + _Time.y * 10) * 0.05 * melt;
+                float t = _Time.y * _Speed;
+                float2 ruv = uv * _BlockSize;
+                float2 id = floor(ruv);
+                float rnd = rand(id.xx);
+                float2 offsetUv = ruv;
+                offsetUv.y += t * (rnd * 0.75 + 0.5) * _Intensity;
+                float2 guv = frac(offsetUv);
+                offsetUv = floor(offsetUv) + guv;
+                uv = offsetUv / _BlockSize;
+                uv.x += sin(uv.y * 10 + t) * _Jitter * _Intensity;
                 return uv;
             }
 

--- a/Assets/Shaders/PixelArt/SpriteMeltOutline.shader.meta
+++ b/Assets/Shaders/PixelArt/SpriteMeltOutline.shader.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f56b21c805f24f33b172294b9a0f5edb
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  validGlobalKeywords: []
+  invalidGlobalKeywords: []
+  validLocalKeywords: []
+  invalidLocalKeywords: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/PixelArt/SpriteMorph 1.mat
+++ b/Assets/Shaders/PixelArt/SpriteMorph 1.mat
@@ -45,10 +45,10 @@ Material:
     - _Amplitude: 0.968
     - _EnableExternalAlpha: 0
     - _Frequency: 47.08
-    - _Intensity: 0.0125
-    - _NoiseScale: 4
+    - _Intensity: 0.00625
+    - _NoiseScale: 6
     - _OutlineSize: 1
-    - _Speed: 1
+    - _Speed: 0.25
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _Flip: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Shaders/PixelArt/SpriteMorph 1.mat
+++ b/Assets/Shaders/PixelArt/SpriteMorph 1.mat
@@ -1,0 +1,57 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SpriteMorph 1
+  m_Shader: {fileID: 4800000, guid: 72e97ce84caf4e1ca43d5d79906cbb3c, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Amount: 0.046
+    - _Amplitude: 0.968
+    - _EnableExternalAlpha: 0
+    - _Frequency: 47.08
+    - _Intensity: 0.0125
+    - _NoiseScale: 4
+    - _OutlineSize: 1
+    - _Speed: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _OutlineColor: {r: 1, g: 1, b: 0, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Shaders/PixelArt/SpriteMorph 1.mat.meta
+++ b/Assets/Shaders/PixelArt/SpriteMorph 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d679be60a0bd60f48a1a6e881053dcea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/PixelArt/SpriteMorph.mat
+++ b/Assets/Shaders/PixelArt/SpriteMorph.mat
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SpriteMorph
+  m_Shader: {fileID: 4800000, guid: 72e97ce84caf4e1ca43d5d79906cbb3c, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Amount: 0.046
+    - _Amplitude: 0.968
+    - _EnableExternalAlpha: 0
+    - _Frequency: 47.08
+    - _Intensity: 0.006
+    - _NoiseScale: 79.95
+    - _Speed: 21.2
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Shaders/PixelArt/SpriteMorph.mat.meta
+++ b/Assets/Shaders/PixelArt/SpriteMorph.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1b37b6ac278ac04195a1a14658b3cf8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/PixelArt/SpriteMorph.shader
+++ b/Assets/Shaders/PixelArt/SpriteMorph.shader
@@ -1,0 +1,59 @@
+Shader "Custom/PixelArt/Morph"
+{
+    Properties
+    {
+        _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Amplitude ("Morph Amplitude", Range(0,1)) = 0.1
+        _Frequency ("Morph Frequency", Float) = 5
+        _Speed ("Morph Speed", Float) = 1
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float _Amplitude;
+            float _Frequency;
+            float _Speed;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                float wave = sin(_Time.y * _Speed + v.vertex.x * _Frequency) * _Amplitude;
+                v.vertex.y += wave;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                return tex2D(_MainTex, i.uv);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PixelArt/SpriteMorph.shader
+++ b/Assets/Shaders/PixelArt/SpriteMorph.shader
@@ -3,6 +3,7 @@ Shader "Custom/PixelArt/Morph"
     Properties
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
         _Amplitude ("Morph Amplitude", Range(0,1)) = 0.1
         _Frequency ("Morph Frequency", Float) = 5
         _Speed ("Morph Speed", Float) = 1
@@ -26,15 +27,18 @@ Shader "Custom/PixelArt/Morph"
             {
                 float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             struct v2f
             {
                 float4 vertex : SV_POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             sampler2D _MainTex;
+            fixed4 _Color;
             float _Amplitude;
             float _Frequency;
             float _Speed;
@@ -46,12 +50,13 @@ Shader "Custom/PixelArt/Morph"
                 v.vertex.y += wave;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
+                o.color = v.color * _Color;
                 return o;
             }
 
             fixed4 frag (v2f i) : SV_Target
             {
-                return tex2D(_MainTex, i.uv);
+                return tex2D(_MainTex, i.uv) * i.color;
             }
             ENDCG
         }

--- a/Assets/Shaders/PixelArt/SpriteMorph.shader
+++ b/Assets/Shaders/PixelArt/SpriteMorph.shader
@@ -4,9 +4,9 @@ Shader "Custom/PixelArt/Morph"
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
         _Color ("Tint", Color) = (1,1,1,1)
-        _Amplitude ("Morph Amplitude", Range(0,1)) = 0.1
-        _Frequency ("Morph Frequency", Float) = 5
+        _NoiseScale ("Noise Scale", Float) = 4
         _Speed ("Morph Speed", Float) = 1
+        _Intensity ("Morph Intensity", Range(0,1)) = 0.1
     }
     SubShader
     {
@@ -39,15 +39,50 @@ Shader "Custom/PixelArt/Morph"
 
             sampler2D _MainTex;
             fixed4 _Color;
-            float _Amplitude;
-            float _Frequency;
+            float _NoiseScale;
             float _Speed;
+            float _Intensity;
+
+            float hash12(float2 p)
+            {
+                float3 p3 = frac(float3(p.xyx) * 0.1031);
+                p3 += dot(p3, p3.yzx + 33.33);
+                return frac((p3.x + p3.y) * p3.z);
+            }
+
+            float perlin(float2 uv)
+            {
+                float2 id = floor(uv);
+                float2 gv = frac(uv);
+                float a = hash12(id);
+                float b = hash12(id + float2(1,0));
+                float c = hash12(id + float2(0,1));
+                float d = hash12(id + float2(1,1));
+                float2 u = gv * gv * (3.0 - 2.0 * gv);
+                return lerp(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+            }
+
+            float2 curl(float2 uv)
+            {
+                float eps = 0.001;
+                float n1 = perlin(uv + float2(0, eps));
+                float n2 = perlin(uv - float2(0, eps));
+                float a = (n1 - n2) / (2.0 * eps);
+                n1 = perlin(uv + float2(eps, 0));
+                n2 = perlin(uv - float2(eps, 0));
+                float b = (n1 - n2) / (2.0 * eps);
+                return float2(a, -b);
+            }
+
+            float2 ApplyMorph(float2 uv)
+            {
+                float2 c = curl(uv * _NoiseScale + _Time.y * _Speed);
+                return uv + c * _Intensity;
+            }
 
             v2f vert (appdata v)
             {
                 v2f o;
-                float wave = sin(_Time.y * _Speed + v.vertex.x * _Frequency) * _Amplitude;
-                v.vertex.y += wave;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 o.color = v.color * _Color;
@@ -56,7 +91,8 @@ Shader "Custom/PixelArt/Morph"
 
             fixed4 frag (v2f i) : SV_Target
             {
-                return tex2D(_MainTex, i.uv) * i.color;
+                float2 uv = ApplyMorph(i.uv);
+                return tex2D(_MainTex, uv) * i.color;
             }
             ENDCG
         }

--- a/Assets/Shaders/PixelArt/SpriteMorph.shader.meta
+++ b/Assets/Shaders/PixelArt/SpriteMorph.shader.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 72e97ce84caf4e1ca43d5d79906cbb3c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  validGlobalKeywords: []
+  invalidGlobalKeywords: []
+  validLocalKeywords: []
+  invalidLocalKeywords: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/PixelArt/SpriteMorphOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteMorphOutline.shader
@@ -1,0 +1,79 @@
+Shader "Custom/PixelArt/MorphOutline"
+{
+    Properties
+    {
+        _MainTex ("Sprite Texture", 2D) = "white" {}
+        _OutlineColor ("Outline Color", Color) = (1,1,0,1)
+        _OutlineSize ("Outline Size", Float) = 1
+        _Amplitude ("Morph Amplitude", Range(0,1)) = 0.1
+        _Frequency ("Morph Frequency", Float) = 5
+        _Speed ("Morph Speed", Float) = 1
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+            fixed4 _OutlineColor;
+            float _OutlineSize;
+            float _Amplitude;
+            float _Frequency;
+            float _Speed;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                float wave = sin(_Time.y * _Speed + v.vertex.x * _Frequency) * _Amplitude;
+                v.vertex.y += wave;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 c = tex2D(_MainTex, i.uv);
+                if (c.a == 0)
+                {
+                    float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
+                    float alpha = 0;
+                    alpha += tex2D(_MainTex, i.uv + float2(offset.x, 0)).a;
+                    alpha += tex2D(_MainTex, i.uv + float2(-offset.x, 0)).a;
+                    alpha += tex2D(_MainTex, i.uv + float2(0, offset.y)).a;
+                    alpha += tex2D(_MainTex, i.uv + float2(0, -offset.y)).a;
+                    if (alpha > 0)
+                    {
+                        return _OutlineColor;
+                    }
+                    return 0;
+                }
+                return c;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PixelArt/SpriteMorphOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteMorphOutline.shader
@@ -3,6 +3,7 @@ Shader "Custom/PixelArt/MorphOutline"
     Properties
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
         _OutlineColor ("Outline Color", Color) = (1,1,0,1)
         _OutlineSize ("Outline Size", Float) = 1
         _Amplitude ("Morph Amplitude", Range(0,1)) = 0.1
@@ -28,16 +29,19 @@ Shader "Custom/PixelArt/MorphOutline"
             {
                 float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             struct v2f
             {
                 float4 vertex : SV_POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             sampler2D _MainTex;
             float4 _MainTex_TexelSize;
+            fixed4 _Color;
             fixed4 _OutlineColor;
             float _OutlineSize;
             float _Amplitude;
@@ -51,12 +55,13 @@ Shader "Custom/PixelArt/MorphOutline"
                 v.vertex.y += wave;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
+                o.color = v.color * _Color;
                 return o;
             }
 
             fixed4 frag (v2f i) : SV_Target
             {
-                fixed4 c = tex2D(_MainTex, i.uv);
+                fixed4 c = tex2D(_MainTex, i.uv) * i.color;
                 if (c.a == 0)
                 {
                     float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
@@ -67,7 +72,7 @@ Shader "Custom/PixelArt/MorphOutline"
                     alpha += tex2D(_MainTex, i.uv + float2(0, -offset.y)).a;
                     if (alpha > 0)
                     {
-                        return _OutlineColor;
+                        return _OutlineColor * i.color;
                     }
                     return 0;
                 }

--- a/Assets/Shaders/PixelArt/SpriteMorphOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteMorphOutline.shader
@@ -6,9 +6,9 @@ Shader "Custom/PixelArt/MorphOutline"
         _Color ("Tint", Color) = (1,1,1,1)
         _OutlineColor ("Outline Color", Color) = (1,1,0,1)
         _OutlineSize ("Outline Size", Float) = 1
-        _Amplitude ("Morph Amplitude", Range(0,1)) = 0.1
-        _Frequency ("Morph Frequency", Float) = 5
+        _NoiseScale ("Noise Scale", Float) = 4
         _Speed ("Morph Speed", Float) = 1
+        _Intensity ("Morph Intensity", Range(0,1)) = 0.1
     }
     SubShader
     {
@@ -44,15 +44,50 @@ Shader "Custom/PixelArt/MorphOutline"
             fixed4 _Color;
             fixed4 _OutlineColor;
             float _OutlineSize;
-            float _Amplitude;
-            float _Frequency;
+            float _NoiseScale;
             float _Speed;
+            float _Intensity;
+
+            float hash12(float2 p)
+            {
+                float3 p3 = frac(float3(p.xyx) * 0.1031);
+                p3 += dot(p3, p3.yzx + 33.33);
+                return frac((p3.x + p3.y) * p3.z);
+            }
+
+            float perlin(float2 uv)
+            {
+                float2 id = floor(uv);
+                float2 gv = frac(uv);
+                float a = hash12(id);
+                float b = hash12(id + float2(1,0));
+                float c = hash12(id + float2(0,1));
+                float d = hash12(id + float2(1,1));
+                float2 u = gv * gv * (3.0 - 2.0 * gv);
+                return lerp(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+            }
+
+            float2 curl(float2 uv)
+            {
+                float eps = 0.001;
+                float n1 = perlin(uv + float2(0, eps));
+                float n2 = perlin(uv - float2(0, eps));
+                float a = (n1 - n2) / (2.0 * eps);
+                n1 = perlin(uv + float2(eps, 0));
+                n2 = perlin(uv - float2(eps, 0));
+                float b = (n1 - n2) / (2.0 * eps);
+                return float2(a, -b);
+            }
+
+            float2 ApplyMorph(float2 uv)
+            {
+                float2 c = curl(uv * _NoiseScale + _Time.y * _Speed);
+                return uv + c * _Intensity;
+            }
 
             v2f vert (appdata v)
             {
                 v2f o;
-                float wave = sin(_Time.y * _Speed + v.vertex.x * _Frequency) * _Amplitude;
-                v.vertex.y += wave;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 o.color = v.color * _Color;
@@ -61,15 +96,16 @@ Shader "Custom/PixelArt/MorphOutline"
 
             fixed4 frag (v2f i) : SV_Target
             {
-                fixed4 c = tex2D(_MainTex, i.uv) * i.color;
+                float2 uv = ApplyMorph(i.uv);
+                fixed4 c = tex2D(_MainTex, uv) * i.color;
                 if (c.a == 0)
                 {
                     float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
                     float alpha = 0;
-                    alpha += tex2D(_MainTex, i.uv + float2(offset.x, 0)).a;
-                    alpha += tex2D(_MainTex, i.uv + float2(-offset.x, 0)).a;
-                    alpha += tex2D(_MainTex, i.uv + float2(0, offset.y)).a;
-                    alpha += tex2D(_MainTex, i.uv + float2(0, -offset.y)).a;
+                    alpha += tex2D(_MainTex, ApplyMorph(i.uv + float2(offset.x, 0))).a;
+                    alpha += tex2D(_MainTex, ApplyMorph(i.uv + float2(-offset.x, 0))).a;
+                    alpha += tex2D(_MainTex, ApplyMorph(i.uv + float2(0, offset.y))).a;
+                    alpha += tex2D(_MainTex, ApplyMorph(i.uv + float2(0, -offset.y))).a;
                     if (alpha > 0)
                     {
                         return _OutlineColor * i.color;

--- a/Assets/Shaders/PixelArt/SpriteMorphOutline.shader.meta
+++ b/Assets/Shaders/PixelArt/SpriteMorphOutline.shader.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 1b59dfc599eb47a881f5368693ea8d5e
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  validGlobalKeywords: []
+  invalidGlobalKeywords: []
+  validLocalKeywords: []
+  invalidLocalKeywords: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/PixelArt/SpriteWobble.mat
+++ b/Assets/Shaders/PixelArt/SpriteWobble.mat
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SpriteWobble
+  m_Shader: {fileID: 4800000, guid: 608b333b42d348ffb7b233f91f273b5d, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Amount: 0.046
+    - _Amplitude: 0.015
+    - _EnableExternalAlpha: 0
+    - _Frequency: 1281.9
+    - _Speed: 15
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Direction: {r: 0, g: 1, b: 0, a: 0}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Shaders/PixelArt/SpriteWobble.mat.meta
+++ b/Assets/Shaders/PixelArt/SpriteWobble.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 322bf3c4e15257a42920b3ecf0781bee
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/PixelArt/SpriteWobble.shader
+++ b/Assets/Shaders/PixelArt/SpriteWobble.shader
@@ -3,6 +3,7 @@ Shader "Custom/PixelArt/Wobble"
     Properties
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
         _Amplitude ("Wobble Amplitude", Range(0,0.5)) = 0.05
         _Frequency ("Wobble Frequency", Float) = 10
         _Speed ("Wobble Speed", Float) = 5
@@ -26,15 +27,18 @@ Shader "Custom/PixelArt/Wobble"
             {
                 float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             struct v2f
             {
                 float4 vertex : SV_POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             sampler2D _MainTex;
+            fixed4 _Color;
             float _Amplitude;
             float _Frequency;
             float _Speed;
@@ -44,6 +48,7 @@ Shader "Custom/PixelArt/Wobble"
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
+                o.color = v.color * _Color;
                 return o;
             }
 
@@ -51,7 +56,7 @@ Shader "Custom/PixelArt/Wobble"
             {
                 float2 uv = i.uv;
                 uv.y += sin(uv.x * _Frequency + _Time.y * _Speed) * _Amplitude;
-                return tex2D(_MainTex, uv);
+                return tex2D(_MainTex, uv) * i.color;
             }
             ENDCG
         }

--- a/Assets/Shaders/PixelArt/SpriteWobble.shader
+++ b/Assets/Shaders/PixelArt/SpriteWobble.shader
@@ -7,6 +7,7 @@ Shader "Custom/PixelArt/Wobble"
         _Amplitude ("Wobble Amplitude", Range(0,0.5)) = 0.05
         _Frequency ("Wobble Frequency", Float) = 10
         _Speed ("Wobble Speed", Float) = 5
+        _Direction ("Wobble Direction", Vector) = (1,0,0,0)
     }
     SubShader
     {
@@ -42,6 +43,7 @@ Shader "Custom/PixelArt/Wobble"
             float _Amplitude;
             float _Frequency;
             float _Speed;
+            float4 _Direction;
 
             v2f vert (appdata v)
             {
@@ -55,7 +57,10 @@ Shader "Custom/PixelArt/Wobble"
             fixed4 frag (v2f i) : SV_Target
             {
                 float2 uv = i.uv;
-                uv.y += sin(uv.x * _Frequency + _Time.y * _Speed) * _Amplitude;
+                float2 dir = normalize(_Direction.xy);
+                float wave = sin(dot(uv, dir) * _Frequency + _Time.y * _Speed) * _Amplitude;
+                float2 perp = float2(-dir.y, dir.x);
+                uv += perp * wave;
                 return tex2D(_MainTex, uv) * i.color;
             }
             ENDCG

--- a/Assets/Shaders/PixelArt/SpriteWobble.shader
+++ b/Assets/Shaders/PixelArt/SpriteWobble.shader
@@ -1,0 +1,59 @@
+Shader "Custom/PixelArt/Wobble"
+{
+    Properties
+    {
+        _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Amplitude ("Wobble Amplitude", Range(0,0.5)) = 0.05
+        _Frequency ("Wobble Frequency", Float) = 10
+        _Speed ("Wobble Speed", Float) = 5
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float _Amplitude;
+            float _Frequency;
+            float _Speed;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float2 uv = i.uv;
+                uv.y += sin(uv.x * _Frequency + _Time.y * _Speed) * _Amplitude;
+                return tex2D(_MainTex, uv);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PixelArt/SpriteWobble.shader.meta
+++ b/Assets/Shaders/PixelArt/SpriteWobble.shader.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 608b333b42d348ffb7b233f91f273b5d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  validGlobalKeywords: []
+  invalidGlobalKeywords: []
+  validLocalKeywords: []
+  invalidLocalKeywords: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/PixelArt/SpriteWobbleOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteWobbleOutline.shader
@@ -9,6 +9,7 @@ Shader "Custom/PixelArt/WobbleOutline"
         _Amplitude ("Wobble Amplitude", Range(0,0.5)) = 0.05
         _Frequency ("Wobble Frequency", Float) = 10
         _Speed ("Wobble Speed", Float) = 5
+        _Direction ("Wobble Direction", Vector) = (1,0,0,0)
     }
     SubShader
     {
@@ -47,10 +48,14 @@ Shader "Custom/PixelArt/WobbleOutline"
             float _Amplitude;
             float _Frequency;
             float _Speed;
+            float4 _Direction;
 
             float2 ApplyWobble(float2 uv)
             {
-                uv.y += sin(uv.x * _Frequency + _Time.y * _Speed) * _Amplitude;
+                float2 dir = normalize(_Direction.xy);
+                float wave = sin(dot(uv, dir) * _Frequency + _Time.y * _Speed) * _Amplitude;
+                float2 perp = float2(-dir.y, dir.x);
+                uv += perp * wave;
                 return uv;
             }
 

--- a/Assets/Shaders/PixelArt/SpriteWobbleOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteWobbleOutline.shader
@@ -1,0 +1,84 @@
+Shader "Custom/PixelArt/WobbleOutline"
+{
+    Properties
+    {
+        _MainTex ("Sprite Texture", 2D) = "white" {}
+        _OutlineColor ("Outline Color", Color) = (1,1,0,1)
+        _OutlineSize ("Outline Size", Float) = 1
+        _Amplitude ("Wobble Amplitude", Range(0,0.5)) = 0.05
+        _Frequency ("Wobble Frequency", Float) = 10
+        _Speed ("Wobble Speed", Float) = 5
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+            fixed4 _OutlineColor;
+            float _OutlineSize;
+            float _Amplitude;
+            float _Frequency;
+            float _Speed;
+
+            float2 ApplyWobble(float2 uv)
+            {
+                uv.y += sin(uv.x * _Frequency + _Time.y * _Speed) * _Amplitude;
+                return uv;
+            }
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float2 uv = ApplyWobble(i.uv);
+                fixed4 c = tex2D(_MainTex, uv);
+                if (c.a == 0)
+                {
+                    float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
+                    float alpha = 0;
+                    alpha += tex2D(_MainTex, ApplyWobble(i.uv + float2(offset.x, 0))).a;
+                    alpha += tex2D(_MainTex, ApplyWobble(i.uv + float2(-offset.x, 0))).a;
+                    alpha += tex2D(_MainTex, ApplyWobble(i.uv + float2(0, offset.y))).a;
+                    alpha += tex2D(_MainTex, ApplyWobble(i.uv + float2(0, -offset.y))).a;
+                    if (alpha > 0)
+                    {
+                        return _OutlineColor;
+                    }
+                    return 0;
+                }
+                return c;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PixelArt/SpriteWobbleOutline.shader
+++ b/Assets/Shaders/PixelArt/SpriteWobbleOutline.shader
@@ -3,6 +3,7 @@ Shader "Custom/PixelArt/WobbleOutline"
     Properties
     {
         _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
         _OutlineColor ("Outline Color", Color) = (1,1,0,1)
         _OutlineSize ("Outline Size", Float) = 1
         _Amplitude ("Wobble Amplitude", Range(0,0.5)) = 0.05
@@ -28,16 +29,19 @@ Shader "Custom/PixelArt/WobbleOutline"
             {
                 float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             struct v2f
             {
                 float4 vertex : SV_POSITION;
                 float2 uv : TEXCOORD0;
+                fixed4 color : COLOR;
             };
 
             sampler2D _MainTex;
             float4 _MainTex_TexelSize;
+            fixed4 _Color;
             fixed4 _OutlineColor;
             float _OutlineSize;
             float _Amplitude;
@@ -55,13 +59,14 @@ Shader "Custom/PixelArt/WobbleOutline"
                 v2f o;
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
+                o.color = v.color * _Color;
                 return o;
             }
 
             fixed4 frag (v2f i) : SV_Target
             {
                 float2 uv = ApplyWobble(i.uv);
-                fixed4 c = tex2D(_MainTex, uv);
+                fixed4 c = tex2D(_MainTex, uv) * i.color;
                 if (c.a == 0)
                 {
                     float2 offset = _MainTex_TexelSize.xy * _OutlineSize;
@@ -72,7 +77,7 @@ Shader "Custom/PixelArt/WobbleOutline"
                     alpha += tex2D(_MainTex, ApplyWobble(i.uv + float2(0, -offset.y))).a;
                     if (alpha > 0)
                     {
-                        return _OutlineColor;
+                        return _OutlineColor * i.color;
                     }
                     return 0;
                 }

--- a/Assets/Shaders/PixelArt/SpriteWobbleOutline.shader.meta
+++ b/Assets/Shaders/PixelArt/SpriteWobbleOutline.shader.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c0478be3fe35407b94e7ea218ea5eb2c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  validGlobalKeywords: []
+  invalidGlobalKeywords: []
+  validLocalKeywords: []
+  invalidLocalKeywords: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- create morphing sprite shader with outline highlight variant
- add wobble shader and matching outline variant
- implement upward melt effect and outline version for proximity highlighting

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8458b230832f8f3f8b4d3411f242