### PR TITLE
feat: add player cough system

### DIFF
--- a/Assets/Scripts/PlayerCough.cs
+++ b/Assets/Scripts/PlayerCough.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// Triggers random coughing fits that temporarily disable player movement.
+/// </summary>
+[RequireComponent(typeof(AudioSource), typeof(PlayerController))]
+public class PlayerCough : MonoBehaviour
+{
+    [Tooltip("Sound that plays when the player coughs.")]
+    [SerializeField] private AudioClip coughClip;
+
+    [Tooltip("Random delay range in seconds between coughs.")]
+    [SerializeField] private Vector2 coughInterval = new Vector2(10f, 30f);
+
+    private PlayerController controller;
+    private AudioSource audioSource;
+
+    private void Awake()
+    {
+        controller = GetComponent<PlayerController>();
+        audioSource = GetComponent<AudioSource>();
+    }
+
+    private void Start()
+    {
+        StartCoroutine(CoughLoop());
+    }
+
+    private IEnumerator CoughLoop()
+    {
+        while (true)
+        {
+            float wait = Random.Range(coughInterval.x, coughInterval.y);
+            yield return new WaitForSeconds(wait);
+            yield return CoughRoutine();
+        }
+    }
+
+    private IEnumerator CoughRoutine()
+    {
+        if (coughClip == null)
+        {
+            yield break;
+        }
+
+        controller.enabled = false;
+        Rigidbody2D rb = controller.GetComponent<Rigidbody2D>();
+        if (rb != null)
+        {
+            rb.velocity = Vector2.zero;
+        }
+
+        audioSource.PlayOneShot(coughClip);
+
+        yield return new WaitForSeconds(coughClip.length);
+
+        controller.enabled = true;
+    }
+}

--- a/Assets/Scripts/PlayerCough.cs.meta
+++ b/Assets/Scripts/PlayerCough.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25f481e687374d21969990479b2a412f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `PlayerCough` component that randomly plays a cough sound
- temporarily disable player movement while coughing

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b21f2e3a14832f8b243a307a61e1fb